### PR TITLE
Generate and insert function py signatures at start of docstring

### DIFF
--- a/bind/types.go
+++ b/bind/types.go
@@ -45,10 +45,23 @@ func cgoTypeName(typ types.Type) string {
 	return typ.String()
 }
 
+func pyTypeName(typ types.Type) string {
+	switch typ := typ.(type) {
+	case *types.Basic:
+		kind := typ.Kind()
+		o, ok := typedescr[kind]
+		if ok {
+			return o.pysig
+		}
+	}
+	return "object"
+}
+
 type typedesc struct {
 	ctype   string
 	cgotype string
 	pyfmt   string
+	pysig   string
 }
 
 var typedescr = map[types.BasicKind]typedesc{
@@ -56,101 +69,118 @@ var typedescr = map[types.BasicKind]typedesc{
 		ctype:   "_Bool",
 		cgotype: "GoBool",
 		pyfmt:   "b",
+		pysig:   "bool",
 	},
 
 	types.Int: typedesc{
 		ctype:   "int",
 		cgotype: "GoInt",
 		pyfmt:   "i",
+		pysig:   "int",
 	},
 
 	types.Int8: typedesc{
 		ctype:   "int8_t",
 		cgotype: "GoInt8",
 		pyfmt:   "c",
+		pysig:   "int",
 	},
 
 	types.Int16: typedesc{
 		ctype:   "int16_t",
 		cgotype: "GoInt16",
 		pyfmt:   "h",
+		pysig:   "int",
 	},
 
 	types.Int32: typedesc{
 		ctype:   "int32_t",
 		cgotype: "GoInt32",
 		pyfmt:   "i",
+		pysig:   "long",
 	},
 
 	types.Int64: typedesc{
 		ctype:   "int64_t",
 		cgotype: "GoInt64",
 		pyfmt:   "k",
+		pysig:   "long",
 	},
 
 	types.Uint: typedesc{
 		ctype:   "unsigned int",
 		cgotype: "GoUint",
 		pyfmt:   "I",
+		pysig:   "int",
 	},
 
 	types.Uint8: typedesc{
 		ctype:   "uint8_t",
 		cgotype: "GoUint8",
 		pyfmt:   "b",
+		pysig:   "int",
 	},
 
 	types.Uint16: typedesc{
 		ctype:   "uint16_t",
 		cgotype: "GoUint16",
 		pyfmt:   "H",
+		pysig:   "int",
 	},
 
 	types.Uint32: typedesc{
 		ctype:   "uint32_t",
 		cgotype: "GoUint32",
 		pyfmt:   "I",
+		pysig:   "long",
 	},
 
 	types.Uint64: typedesc{
 		ctype:   "uint64_t",
 		cgotype: "GoUint64",
 		pyfmt:   "K",
+		pysig:   "long",
 	},
 
 	types.Float32: typedesc{
 		ctype:   "float",
 		cgotype: "float",
 		pyfmt:   "f",
+		pysig:   "float",
 	},
 
 	types.Float64: typedesc{
 		ctype:   "double",
 		cgotype: "double",
 		pyfmt:   "d",
+		pysig:   "float",
 	},
 
 	types.Complex64: typedesc{
 		ctype:   "float complex",
 		cgotype: "GoComplex64",
 		pyfmt:   "D",
+		pysig:   "float",
 	},
 
 	types.Complex128: typedesc{
 		ctype:   "double complex",
 		cgotype: "GoComplex128",
 		pyfmt:   "D",
+		pysig:   "float",
 	},
 
 	types.String: typedesc{
 		ctype:   "const char*",
 		cgotype: "GoString",
 		pyfmt:   "s",
+		pysig:   "str",
 	},
 
 	types.UnsafePointer: typedesc{
 		ctype:   "void*",
 		cgotype: "void*",
 		pyfmt:   "?",
+		pysig:   "object",
 	},
 }


### PR DESCRIPTION
I thought I would try something simple, just to get into this code base. I use cython a lot, and one feature that is really neat is that it can generate a function signature and insert it into the docstring for you. So I threw together roughly that functionality here.

```go
// GetHelloFor generates a hello msg for a person
func GetHelloFor(person string) string {
	return fmt.Sprintf("Hello, %s!", person)
}
```

```
In [2]: print pytest.GetHelloFor.__doc__
GetHelloFor(str person) str

GetHelloFor generates a hello msg for a person
```
