### PR TITLE
refactor gencpy

### DIFF
--- a/_examples/hi/hi.go
+++ b/_examples/hi/hi.go
@@ -57,13 +57,12 @@ func (p *Person) greet() string {
 	return fmt.Sprintf("Hello, I am %s", p.Name)
 }
 
-/*
 // Work makes a Person go to work for h hours
 func (p *Person) Work(h int) error {
 	fmt.Printf("working...\n")
 	if h > 7 {
 		return fmt.Errorf("can't work for %d hours!", h)
 	}
+	fmt.Printf("worked for %d hours\n", h)
 	return nil
 }
-*/

--- a/_examples/hi/hi.go
+++ b/_examples/hi/hi.go
@@ -49,5 +49,10 @@ func (p Person) String() string {
 
 // Greet sends greetings
 func (p *Person) Greet() string {
+	return p.greet()
+}
+
+// greet sends greetings
+func (p *Person) greet() string {
 	return fmt.Sprintf("Hello, I am %s", p.Name)
 }

--- a/_examples/hi/hi.go
+++ b/_examples/hi/hi.go
@@ -56,3 +56,14 @@ func (p *Person) Greet() string {
 func (p *Person) greet() string {
 	return fmt.Sprintf("Hello, I am %s", p.Name)
 }
+
+/*
+// Work makes a Person go to work for h hours
+func (p *Person) Work(h int) error {
+	fmt.Printf("working...\n")
+	if h > 7 {
+		return fmt.Errorf("can't work for %d hours!", h)
+	}
+	return nil
+}
+*/

--- a/_examples/hi/test.py
+++ b/_examples/hi/test.py
@@ -39,6 +39,9 @@ print p.Greet.__doc__
 print "--- p.Greet()..."
 print p.Greet()
 
+print "--- p.String()..."
+print p.String()
+
 print "--- doc(p):"
 print p.__doc__
 

--- a/_examples/hi/test.py
+++ b/_examples/hi/test.py
@@ -57,3 +57,16 @@ print p.String()
 print "--- p.Age:", p.Age
 print "--- p.Name:",p.Name
 
+print "--- p.Work(2)..."
+p.Work(2)
+
+print "--- p.Work(24)..."
+try:
+    p.Work(24)
+    print "*ERROR* no exception raised!"
+except Exception, err:
+    print "caught:", err
+    pass
+
+
+

--- a/_examples/hi/test.py
+++ b/_examples/hi/test.py
@@ -45,3 +45,14 @@ print p.String()
 print "--- doc(p):"
 print p.__doc__
 
+print "--- p.Name = \"foo\"..."
+p.Name = "foo"
+
+print "--- p.Age = 42..."
+p.Age = 42
+
+print "--- p.String()..."
+print p.String()
+print "--- p.Age:", p.Age
+print "--- p.Name:",p.Name
+

--- a/_examples/hi/test.py
+++ b/_examples/hi/test.py
@@ -30,6 +30,7 @@ print hi.Person.__doc__
 print "--- p = hi.Person()..."
 p = hi.Person()
 print dir(p)
+print "--- p:", p
 
 print "--- p.Name:", p.Name
 print "--- p.Age:",p.Age

--- a/_examples/hi/test.py
+++ b/_examples/hi/test.py
@@ -34,8 +34,10 @@ print dir(p)
 print "--- p.Name:", p.Name
 print "--- p.Age:",p.Age
 
-#print "--- p.Greet()..."
-#print p.Greet()
+print "--- doc(hi.Greet):"
+print p.Greet.__doc__
+print "--- p.Greet()..."
+print p.Greet()
 
 print "--- doc(p):"
 print p.__doc__

--- a/_examples/hi/test.py
+++ b/_examples/hi/test.py
@@ -29,11 +29,13 @@ print hi.Person.__doc__
 
 print "--- p = hi.Person()..."
 p = hi.Person()
-print p
 print dir(p)
 
 print "--- p.Name:", p.Name
 print "--- p.Age:",p.Age
+
+#print "--- p.Greet()..."
+#print p.Greet()
 
 print "--- doc(p):"
 print p.__doc__

--- a/bind/bind.go
+++ b/bind/bind.go
@@ -28,10 +28,9 @@ func (list ErrorList) Error() string {
 
 // GenCPython generates a (C)Python package from a Go package
 func GenCPython(w io.Writer, fset *token.FileSet, pkg *Package) error {
-	buf := new(bytes.Buffer)
 	gen := &cpyGen{
-		decl: &printer{buf: buf, indentEach: []byte("\t")},
-		impl: &printer{buf: buf, indentEach: []byte("\t")},
+		decl: &printer{buf: new(bytes.Buffer), indentEach: []byte("\t")},
+		impl: &printer{buf: new(bytes.Buffer), indentEach: []byte("\t")},
 		fset: fset,
 		pkg:  pkg,
 	}

--- a/bind/bind.go
+++ b/bind/bind.go
@@ -7,12 +7,9 @@ package bind
 import (
 	"bytes"
 	"fmt"
-	"go/doc"
 	"go/token"
 	"io"
 	"os"
-
-	"golang.org/x/tools/go/types"
 )
 
 // ErrorList is a list of errors
@@ -27,69 +24,6 @@ func (list ErrorList) Error() string {
 		io.WriteString(buf, err.Error())
 	}
 	return buf.String()
-}
-
-// Package ties types.Package and ast.Package together
-type Package struct {
-	pkg *types.Package
-	doc *doc.Package
-}
-
-// NewPackage creates a new Package, tying types.Package and ast.Package together.
-func NewPackage(pkg *types.Package, doc *doc.Package) *Package {
-	return &Package{
-		pkg: pkg,
-		doc: doc,
-	}
-}
-
-// Name returns the package name.
-func (p *Package) Name() string {
-	return p.pkg.Name()
-}
-
-// getDoc returns the doc string associated with types.Object
-func (p *Package) getDoc(o types.Object) string {
-	n := o.Name()
-	switch o.(type) {
-	case *types.Const:
-		for _, c := range p.doc.Consts {
-			for _, cn := range c.Names {
-				if n == cn {
-					return c.Doc
-				}
-			}
-		}
-
-	case *types.Var:
-		for _, v := range p.doc.Vars {
-			for _, vn := range v.Names {
-				if n == vn {
-					return v.Doc
-				}
-			}
-		}
-
-	case *types.Func:
-		for _, f := range p.doc.Funcs {
-			if n == f.Name {
-				return f.Doc
-			}
-		}
-
-	case *types.TypeName:
-		for _, t := range p.doc.Types {
-			if n == t.Name {
-				return t.Doc
-			}
-		}
-
-	default:
-		// TODO(sbinet)
-		panic(fmt.Errorf("not yet supported: %v (%T)", o, o))
-	}
-
-	return ""
 }
 
 // GenCPython generates a (C)Python package from a Go package

--- a/bind/bind.go
+++ b/bind/bind.go
@@ -40,12 +40,12 @@ func GenCPython(w io.Writer, fset *token.FileSet, pkg *Package) error {
 		return err
 	}
 
-	_, err = io.Copy(w, gen.decl.buf)
+	_, err = io.Copy(w, gen.decl)
 	if err != nil {
 		return err
 	}
 
-	_, err = io.Copy(w, gen.impl.buf)
+	_, err = io.Copy(w, gen.impl)
 	if err != nil {
 		return err
 	}

--- a/bind/gencpy.go
+++ b/bind/gencpy.go
@@ -224,7 +224,7 @@ func (g *cpyGen) genFuncBody(id string, sig *types.Signature) {
 }
 
 func (g *cpyGen) genStruct(cpy Struct) {
-	pkgname := cpy.Obj().Pkg().Name()
+	pkgname := cpy.GoObj().Pkg().Name()
 
 	//fmt.Printf("obj: %#v\ntyp: %#v\n", obj, typ)
 	g.decl.Printf("/* --- decls for struct %s.%v --- */\n", pkgname, cpy.GoName())
@@ -293,7 +293,7 @@ func (g *cpyGen) genStruct(cpy Struct) {
 }
 
 func (g *cpyGen) genStructDealloc(cpy Struct) {
-	pkgname := cpy.Obj().Pkg().Name()
+	pkgname := cpy.GoObj().Pkg().Name()
 
 	g.decl.Printf("/* tp_dealloc for %s.%v */\n", pkgname, cpy.GoName())
 	g.decl.Printf("static void\n_gopy_%[1]s_dealloc(_gopy_%[1]s *self);\n",
@@ -311,7 +311,7 @@ func (g *cpyGen) genStructDealloc(cpy Struct) {
 }
 
 func (g *cpyGen) genStructNew(cpy Struct) {
-	pkgname := cpy.Obj().Pkg().Name()
+	pkgname := cpy.GoObj().Pkg().Name()
 
 	g.decl.Printf("/* tp_new for %s.%v */\n", pkgname, cpy.GoName())
 	g.decl.Printf(
@@ -334,7 +334,7 @@ func (g *cpyGen) genStructNew(cpy Struct) {
 }
 
 func (g *cpyGen) genStructInit(cpy Struct) {
-	pkgname := cpy.Obj().Pkg().Name()
+	pkgname := cpy.GoObj().Pkg().Name()
 
 	g.decl.Printf("/* tp_init for %s.%v */\n", pkgname, cpy.GoName())
 	g.decl.Printf(
@@ -354,7 +354,7 @@ func (g *cpyGen) genStructInit(cpy Struct) {
 }
 
 func (g *cpyGen) genStructMembers(cpy Struct) {
-	pkgname := cpy.Obj().Pkg().Name()
+	pkgname := cpy.GoObj().Pkg().Name()
 	typ := cpy.Struct()
 
 	g.decl.Printf("/* tp_getset for %s.%v */\n", pkgname, cpy.GoName())
@@ -484,7 +484,7 @@ func (g *cpyGen) genStructMembers(cpy Struct) {
 
 func (g *cpyGen) genStructMethods(cpy Struct) {
 
-	pkgname := cpy.Obj().Pkg().Name()
+	pkgname := cpy.GoObj().Pkg().Name()
 
 	g.decl.Printf("/* methods for %s.%s */\n\n", pkgname, cpy.GoName())
 	for _, m := range cpy.meths {

--- a/bind/gencpy.go
+++ b/bind/gencpy.go
@@ -387,19 +387,6 @@ func (g *cpyGen) genStructMembers(cpy Struct) {
 	g.impl.Outdent()
 	g.impl.Printf("};\n\n")
 	/*
-		static PyGetSetDef Noddy_getseters[] = {
-		    {"first",
-		     (getter)Noddy_getfirst, (setter)Noddy_setfirst,
-		     "first name",
-		     NULL},
-		    {"last",
-		     (getter)Noddy_getlast, (setter)Noddy_setlast,
-		     "last name",
-		     NULL},
-		    {NULL}
-		};
-	*/
-	/*
 				static PyObject *
 				Noddy_getfirst(Noddy *self, void *closure)
 				{
@@ -633,11 +620,6 @@ func (g *cpyGen) genStructMethods(cpy Struct) {
 			margs,
 			m.Doc(),
 		)
-		/*
-			{"name", (PyCFunction)Noddy_name, METH_NOARGS,
-			     "Return the name, combining the first and last name"
-			    },
-		*/
 	}
 	g.impl.Printf("{NULL} /* sentinel */\n")
 	g.impl.Outdent()

--- a/bind/gencpy.go
+++ b/bind/gencpy.go
@@ -9,6 +9,8 @@ import (
 	"go/token"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/tools/go/types"
 )
 
 const (
@@ -113,12 +115,15 @@ gopy_%[3]s(PyObject *self, PyObject *args) {
 	)
 
 	g.impl.Indent()
-	g.genFuncBody(o.ID(), o.Signature())
+	g.genFuncBody(o)
 	g.impl.Outdent()
 	g.impl.Printf("}\n\n")
 }
 
-func (g *cpyGen) genFuncBody(id string, sig *Signature) {
+func (g *cpyGen) genFuncBody(f Func) {
+	id := f.ID()
+	sig := f.Signature()
+
 	funcArgs := []string{}
 
 	res := sig.Results()
@@ -188,7 +193,6 @@ func (g *cpyGen) genFuncBody(id string, sig *Signature) {
 	if len(res) > 0 {
 		g.impl.Printf("c_gopy_ret = ")
 	}
-
 	g.impl.Printf("GoPy_%[1]s(%[2]s);\n", id, strings.Join(funcArgs, ", "))
 
 	g.impl.Printf("\n")
@@ -530,13 +534,13 @@ func (g *cpyGen) genMethod(cpy Struct, fct Func) {
 	g.impl.Printf("static PyObject*\n")
 	g.impl.Printf("gopy_%s(PyObject *self, PyObject *args) {\n", fct.ID())
 	g.impl.Indent()
-	g.genMethodBody(cpy, fct)
+	g.genMethodBody(fct)
 	g.impl.Outdent()
 	g.impl.Printf("}\n\n")
 }
 
-func (g *cpyGen) genMethodBody(cpy Struct, fct Func) {
-	g.genFuncBody(fct.ID(), fct.Signature())
+func (g *cpyGen) genMethodBody(fct Func) {
+	g.genFuncBody(fct)
 }
 
 func (g *cpyGen) genPreamble() {

--- a/bind/gencpy.go
+++ b/bind/gencpy.go
@@ -9,8 +9,6 @@ import (
 	"go/token"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/tools/go/types"
 )
 
 const (
@@ -120,14 +118,14 @@ gopy_%[3]s(PyObject *self, PyObject *args) {
 	g.impl.Printf("}\n\n")
 }
 
-func (g *cpyGen) genFuncBody(id string, sig *types.Signature) {
+func (g *cpyGen) genFuncBody(id string, sig *Signature) {
 	funcArgs := []string{}
 
-	res := newVars(sig.Results())
-	args := newVars(sig.Params())
+	res := sig.Results()
+	args := sig.Params()
 	var recv *Var
 	if sig.Recv() != nil {
-		recv = newVar(sig.Recv())
+		recv = sig.Recv()
 		recv.genRecvDecl(g.impl)
 		funcArgs = append(funcArgs, recv.getFuncArg())
 	}

--- a/bind/gencpy.go
+++ b/bind/gencpy.go
@@ -355,7 +355,7 @@ func (g *cpyGen) genStructInit(cpy Struct) {
 
 func (g *cpyGen) genStructMembers(cpy Struct) {
 	pkgname := cpy.Obj().Pkg().Name()
-	typ := cpy.GoType().(*types.Struct)
+	typ := cpy.Struct()
 
 	g.decl.Printf("/* tp_getset for %s.%v */\n", pkgname, cpy.GoName())
 	for i := 0; i < typ.NumFields(); i++ {

--- a/bind/gencpy.go
+++ b/bind/gencpy.go
@@ -388,36 +388,6 @@ func (g *cpyGen) genStructMembers(cpy Struct) {
 	g.impl.Printf("{NULL} /* Sentinel */\n")
 	g.impl.Outdent()
 	g.impl.Printf("};\n\n")
-	/*
-				static PyObject *
-				Noddy_getfirst(Noddy *self, void *closure)
-				{
-				    Py_INCREF(self->first);
-				    return self->first;
-				}
-
-				static int
-		Noddy_setfirst(Noddy *self, PyObject *value, void *closure)
-		{
-		  if (value == NULL) {
-		    PyErr_SetString(PyExc_TypeError, "Cannot delete the first attribute");
-		    return -1;
-		  }
-
-		  if (! PyString_Check(value)) {
-		    PyErr_SetString(PyExc_TypeError,
-		                    "The first attribute value must be a string");
-		    return -1;
-		  }
-
-		  Py_DECREF(self->first);
-		  Py_INCREF(value);
-		  self->first = value;
-
-		  return 0;
-		}
-	*/
-
 }
 
 func (g *cpyGen) genStructMemberGetter(cpy Struct, i int, f types.Object) {

--- a/bind/gencpy.go
+++ b/bind/gencpy.go
@@ -526,6 +526,8 @@ func (g *cpyGen) genMethod(cpy Struct, m Method) {
 }
 
 func (g *cpyGen) genMethodBody(cpy Struct, m Method) {
+	//FIXME(sbinet)
+	g.impl.Printf("Py_INCREF(Py_None);\nreturn Py_None;\n")
 }
 
 func (g *cpyGen) genPreamble() {

--- a/bind/gencpy.go
+++ b/bind/gencpy.go
@@ -222,7 +222,7 @@ func (g *cpyGen) genFuncBody(id string, sig *Signature) {
 }
 
 func (g *cpyGen) genStruct(cpy Struct) {
-	pkgname := cpy.GoObj().Pkg().Name()
+	pkgname := cpy.Package().Name()
 
 	//fmt.Printf("obj: %#v\ntyp: %#v\n", obj, typ)
 	g.decl.Printf("/* --- decls for struct %s.%v --- */\n", pkgname, cpy.GoName())
@@ -291,7 +291,7 @@ func (g *cpyGen) genStruct(cpy Struct) {
 }
 
 func (g *cpyGen) genStructDealloc(cpy Struct) {
-	pkgname := cpy.GoObj().Pkg().Name()
+	pkgname := cpy.Package().Name()
 
 	g.decl.Printf("/* tp_dealloc for %s.%v */\n", pkgname, cpy.GoName())
 	g.decl.Printf("static void\n_gopy_%[1]s_dealloc(_gopy_%[1]s *self);\n",
@@ -309,7 +309,7 @@ func (g *cpyGen) genStructDealloc(cpy Struct) {
 }
 
 func (g *cpyGen) genStructNew(cpy Struct) {
-	pkgname := cpy.GoObj().Pkg().Name()
+	pkgname := cpy.Package().Name()
 
 	g.decl.Printf("/* tp_new for %s.%v */\n", pkgname, cpy.GoName())
 	g.decl.Printf(
@@ -332,7 +332,7 @@ func (g *cpyGen) genStructNew(cpy Struct) {
 }
 
 func (g *cpyGen) genStructInit(cpy Struct) {
-	pkgname := cpy.GoObj().Pkg().Name()
+	pkgname := cpy.Package().Name()
 
 	g.decl.Printf("/* tp_init for %s.%v */\n", pkgname, cpy.GoName())
 	g.decl.Printf(
@@ -352,7 +352,7 @@ func (g *cpyGen) genStructInit(cpy Struct) {
 }
 
 func (g *cpyGen) genStructMembers(cpy Struct) {
-	pkgname := cpy.GoObj().Pkg().Name()
+	pkgname := cpy.Package().Name()
 	typ := cpy.Struct()
 
 	g.decl.Printf("/* tp_getset for %s.%v */\n", pkgname, cpy.GoName())
@@ -482,7 +482,7 @@ func (g *cpyGen) genStructMembers(cpy Struct) {
 
 func (g *cpyGen) genStructMethods(cpy Struct) {
 
-	pkgname := cpy.GoObj().Pkg().Name()
+	pkgname := cpy.Package().Name()
 
 	g.decl.Printf("/* methods for %s.%s */\n\n", pkgname, cpy.GoName())
 	for _, m := range cpy.meths {

--- a/bind/gengo.go
+++ b/bind/gengo.go
@@ -164,7 +164,7 @@ func (g *goGen) genFuncBody(f Func) {
 
 func (g *goGen) genStruct(s Struct) {
 	//fmt.Printf("obj: %#v\ntyp: %#v\n", obj, typ)
-	typ := s.GoType().(*types.Struct)
+	typ := s.Struct()
 	pkgname := s.Obj().Pkg().Name()
 	g.Printf("//export GoPy_%[1]s\n", s.ID())
 	g.Printf("type GoPy_%[1]s unsafe.Pointer\n\n", s.ID())

--- a/bind/gengo.go
+++ b/bind/gengo.go
@@ -98,11 +98,12 @@ func (g *goGen) genFunc(f Func) {
 	//funcName := o.Name()
 	g.Printf(`
 //export GoPy_%[1]s
-// GoPy_%[1]s wraps %[2]s
-func GoPy_%[1]s%[3]v%[4]v{
+// GoPy_%[1]s wraps %[2]s.%[3]s
+func GoPy_%[1]s%[4]v%[5]v{
 `,
 		f.ID(),
-		f.GoObj().Name(),
+		f.Package().Name(),
+		f.GoName(),
 		params,
 		ret,
 	)
@@ -164,7 +165,7 @@ func (g *goGen) genFuncBody(f Func) {
 func (g *goGen) genStruct(s Struct) {
 	//fmt.Printf("obj: %#v\ntyp: %#v\n", obj, typ)
 	typ := s.Struct()
-	pkgname := s.GoObj().Pkg().Name()
+	pkgname := s.Package().Name()
 	g.Printf("//export GoPy_%[1]s\n", s.ID())
 	g.Printf("type GoPy_%[1]s unsafe.Pointer\n\n", s.ID())
 

--- a/bind/gengo.go
+++ b/bind/gengo.go
@@ -45,6 +45,16 @@ func CGoPy_CString(s string) *C.char {
 	return C.CString(s)
 }
 
+//export CGoPy_ErrorIsNil
+func CGoPy_ErrorIsNil(err error) bool {
+	return err == nil
+}
+
+//export CGoPy_ErrorString
+func CGoPy_ErrorString(err error) *C.char {
+	return C.CString(err.Error())
+}
+
 // --- end cgo helpers ---
 `
 )
@@ -349,10 +359,16 @@ func (g *goGen) qualifiedType(typ types.Type) string {
 	case *types.Named:
 		obj := typ.Obj()
 		//return obj.Pkg().Name() + "." + obj.Name()
-		return "GoPy_" + obj.Name()
+		//return "GoPy_" + obj.Name()
 		switch typ := typ.Underlying().(type) {
 		case *types.Struct:
+			return "GoPy_" + obj.Name()
 			return typ.String()
+		case *types.Interface:
+			if obj.Name() == "error" {
+				return "error"
+			}
+			return "GoPy_" + obj.Name()
 		default:
 			return "GoPy_ooops_" + obj.Name()
 		}

--- a/bind/gengo.go
+++ b/bind/gengo.go
@@ -89,7 +89,7 @@ func (g *goGen) genFunc(f Func) {
 
 	params := "(" + g.tupleString(sig.Params()) + ")"
 	ret := g.tupleString(sig.Results())
-	if sig.Results().Len() > 1 {
+	if len(sig.Results()) > 1 {
 		ret = "(" + ret + ") "
 	} else {
 		ret += " "
@@ -115,7 +115,7 @@ func GoPy_%[1]s%[3]v%[4]v{
 
 func (g *goGen) genFuncBody(f Func) {
 	sig := f.Signature()
-	results := newVars(sig.Results())
+	results := sig.Results()
 	for i := range results {
 		if i > 0 {
 			g.Printf(", ")
@@ -129,10 +129,9 @@ func (g *goGen) genFuncBody(f Func) {
 	g.Printf("%s.%s(", g.pkg.Name(), f.GoName())
 
 	args := sig.Params()
-	for i := 0; i < args.Len(); i++ {
-		arg := args.At(i)
+	for i, arg := range args {
 		tail := ""
-		if i+1 < args.Len() {
+		if i+1 < len(args) {
 			tail = ", "
 		}
 		g.Printf("%s%s", arg.Name(), tail)
@@ -223,13 +222,13 @@ func (g *goGen) genStruct(s Struct) {
 func (g *goGen) genMethod(s Struct, m Func) {
 	sig := m.Signature()
 	params := "(self GoPy_" + s.ID()
-	if sig.Params().Len() > 0 {
+	if len(sig.Params()) > 0 {
 		params += ", " + g.tupleString(sig.Params())
 	}
 	params += ")"
 
 	ret := g.tupleString(sig.Results())
-	if sig.Results().Len() > 1 {
+	if len(sig.Results()) > 1 {
 		ret = "(" + ret + ")"
 	} else {
 		ret += " "
@@ -249,7 +248,7 @@ func (g *goGen) genMethod(s Struct, m Func) {
 
 func (g *goGen) genMethodBody(s Struct, m Func) {
 	sig := m.Signature()
-	results := newVars(sig.Results())
+	results := sig.Results()
 	for i := range results {
 		if i > 0 {
 			g.Printf(", ")
@@ -266,10 +265,9 @@ func (g *goGen) genMethodBody(s Struct, m Func) {
 	)
 
 	args := sig.Params()
-	for i := 0; i < args.Len(); i++ {
-		arg := args.At(i)
+	for i, arg := range args {
 		tail := ""
-		if i+1 < args.Len() {
+		if i+1 < len(args) {
 			tail = ", "
 		}
 		g.Printf("%s%s", arg.Name(), tail)
@@ -305,17 +303,16 @@ func (g *goGen) genPreamble() {
 	g.Printf(goPreamble, n, g.pkg.pkg.Path(), filepath.Base(n))
 }
 
-func (g *goGen) tupleString(tuple *types.Tuple) string {
-	n := tuple.Len()
+func (g *goGen) tupleString(tuple []*Var) string {
+	n := len(tuple)
 	if n <= 0 {
 		return ""
 	}
 
 	str := make([]string, 0, n)
-	for i := 0; i < tuple.Len(); i++ {
-		v := tuple.At(i)
+	for _, v := range tuple {
 		n := v.Name()
-		typ := v.Type()
+		typ := v.GoType()
 		str = append(str, n+" "+g.qualifiedType(typ))
 	}
 

--- a/bind/gengo.go
+++ b/bind/gengo.go
@@ -102,7 +102,7 @@ func (g *goGen) genFunc(f Func) {
 func GoPy_%[1]s%[3]v%[4]v{
 `,
 		f.ID(),
-		f.Obj().Name(),
+		f.GoObj().Name(),
 		params,
 		ret,
 	)
@@ -165,7 +165,7 @@ func (g *goGen) genFuncBody(f Func) {
 func (g *goGen) genStruct(s Struct) {
 	//fmt.Printf("obj: %#v\ntyp: %#v\n", obj, typ)
 	typ := s.Struct()
-	pkgname := s.Obj().Pkg().Name()
+	pkgname := s.GoObj().Pkg().Name()
 	g.Printf("//export GoPy_%[1]s\n", s.ID())
 	g.Printf("type GoPy_%[1]s unsafe.Pointer\n\n", s.ID())
 

--- a/bind/package.go
+++ b/bind/package.go
@@ -211,6 +211,9 @@ func (p *Package) process() error {
 				return err
 			}
 			s.meths = append(s.meths, m)
+			if isStringer(meth.Obj()) {
+				s.prots |= ProtoStringer
+			}
 		}
 		p.addStruct(s)
 	}
@@ -248,6 +251,13 @@ func (p *Package) Lookup(o types.Object) (Object, bool) {
 	return obj, ok
 }
 
+// Protocol encodes the various protocols a python type may implement
+type Protocol int
+
+const (
+	ProtoStringer Protocol = 1 << iota
+)
+
 // Struct collects informations about a go struct.
 type Struct struct {
 	pkg *Package
@@ -257,6 +267,8 @@ type Struct struct {
 	doc   string
 	ctors []Func
 	meths []Func
+
+	prots Protocol
 }
 
 func newStruct(p *Package, obj *types.TypeName) (Struct, error) {

--- a/bind/package.go
+++ b/bind/package.go
@@ -289,10 +289,6 @@ func (s Struct) GoName() string {
 	return s.obj.Name()
 }
 
-func (s Struct) GoObj() types.Object {
-	return s.obj
-}
-
 func (s Struct) Struct() *types.Struct {
 	return s.obj.Type().Underlying().(*types.Struct)
 }
@@ -399,10 +395,6 @@ func (f Func) GoType() types.Type {
 
 func (f Func) GoName() string {
 	return f.obj.Name()
-}
-
-func (f Func) GoObj() types.Object {
-	return f.obj
 }
 
 func (f Func) Signature() *Signature {

--- a/bind/package.go
+++ b/bind/package.go
@@ -293,7 +293,7 @@ func (s Struct) Struct() *types.Struct {
 	return s.obj.Type().Underlying().(*types.Struct)
 }
 
-// Signature
+// A Signature represents a (non-builtin) function or method type.
 type Signature struct {
 	ret  []*Var
 	args []*Var

--- a/bind/package.go
+++ b/bind/package.go
@@ -313,6 +313,14 @@ func newSignatureFrom(pkg *Package, sig *types.Signature) *Signature {
 	}
 }
 
+func newSignature(pkg *Package, recv *Var, params, results []*Var) *Signature {
+	return &Signature{
+		ret:  results,
+		args: params,
+		recv: recv,
+	}
+}
+
 func (sig *Signature) Results() []*Var {
 	return sig.ret
 }
@@ -327,9 +335,10 @@ func (sig *Signature) Recv() *Var {
 
 // Func collects informations about a go func/method.
 type Func struct {
-	pkg *Package
-	sig *Signature
-	obj types.Object
+	pkg  *Package
+	sig  *Signature
+	typ  types.Type
+	name string
 
 	id  string
 	doc string
@@ -367,13 +376,14 @@ func newFuncFrom(p *Package, parent string, obj types.Object, sig *types.Signatu
 	}
 
 	return Func{
-		pkg: p,
-		sig: newSignatureFrom(p, sig),
-		obj: obj,
-		id:  obj.Pkg().Name() + "_" + obj.Name(),
-		doc: p.getDoc(parent, obj),
-		ret: ret,
-		err: haserr,
+		pkg:  p,
+		sig:  newSignatureFrom(p, sig),
+		typ:  obj.Type(),
+		name: obj.Name(),
+		id:   obj.Pkg().Name() + "_" + obj.Name(),
+		doc:  p.getDoc(parent, obj),
+		ret:  ret,
+		err:  haserr,
 	}, nil
 }
 
@@ -390,11 +400,11 @@ func (f Func) Doc() string {
 }
 
 func (f Func) GoType() types.Type {
-	return f.obj.Type()
+	return f.typ
 }
 
 func (f Func) GoName() string {
-	return f.obj.Name()
+	return f.name
 }
 
 func (f Func) Signature() *Signature {

--- a/bind/package.go
+++ b/bind/package.go
@@ -1,0 +1,351 @@
+// Copyright 2015 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bind
+
+import (
+	"fmt"
+	"go/doc"
+	"strings"
+
+	"golang.org/x/tools/go/types"
+)
+
+// Package ties types.Package and ast.Package together.
+// Package also collects informations about structs and funcs.
+type Package struct {
+	pkg *types.Package
+	doc *doc.Package
+
+	structs []Struct
+	funcs   []Func
+}
+
+// NewPackage creates a new Package, tying types.Package and ast.Package together.
+func NewPackage(pkg *types.Package, doc *doc.Package) (*Package, error) {
+	p := &Package{
+		pkg: pkg,
+		doc: doc,
+	}
+	err := p.process()
+	if err != nil {
+		return nil, err
+	}
+	return p, err
+}
+
+// Name returns the package name.
+func (p *Package) Name() string {
+	return p.pkg.Name()
+}
+
+// getDoc returns the doc string associated with types.Object
+// parent is the name of the containing scope ("" for global scope)
+func (p *Package) getDoc(parent string, o types.Object) string {
+	n := o.Name()
+	switch o.(type) {
+	case *types.Const:
+		for _, c := range p.doc.Consts {
+			for _, cn := range c.Names {
+				if n == cn {
+					return c.Doc
+				}
+			}
+		}
+
+	case *types.Var:
+		for _, v := range p.doc.Vars {
+			for _, vn := range v.Names {
+				if n == vn {
+					return v.Doc
+				}
+			}
+		}
+
+	case *types.Func:
+		doc := func() string {
+			if o.Parent() == nil {
+				for _, typ := range p.doc.Types {
+					if typ.Name != parent {
+						continue
+					}
+					for _, m := range typ.Methods {
+						if m.Name == n {
+							return m.Doc
+						}
+					}
+				}
+			} else {
+				for _, f := range p.doc.Funcs {
+					if n == f.Name {
+						return f.Doc
+					}
+				}
+			}
+			return ""
+		}()
+
+		sig := o.Type().(*types.Signature)
+
+		parseFn := func(tup *types.Tuple) []string {
+			params := []string{}
+			if tup == nil {
+				return params
+			}
+			for i := 0; i < tup.Len(); i++ {
+				paramVar := tup.At(i)
+				paramType := pyTypeName(paramVar.Type())
+				if paramVar.Name() != "" {
+					paramType = fmt.Sprintf("%s %s", paramType, paramVar.Name())
+				}
+				params = append(params, paramType)
+			}
+			return params
+		}
+
+		params := parseFn(sig.Params())
+		results := parseFn(sig.Results())
+
+		paramString := strings.Join(params, ", ")
+		resultString := strings.Join(results, ", ")
+
+		//FIXME(sbinet): add receiver for methods?
+		docSig := fmt.Sprintf("%s(%s) %s", o.Name(), paramString, resultString)
+
+		if doc != "" {
+			doc = fmt.Sprintf("%s\n\n%s", docSig, doc)
+		} else {
+			doc = docSig
+		}
+		return doc
+
+	case *types.TypeName:
+		for _, t := range p.doc.Types {
+			if n == t.Name {
+				return t.Doc
+			}
+		}
+
+	default:
+		// TODO(sbinet)
+		panic(fmt.Errorf("not yet supported: %v (%T)", o, o))
+	}
+
+	return ""
+}
+
+// process collects informations about a go package.
+func (p *Package) process() error {
+	var err error
+
+	funcs := make(map[string]Func)
+	structs := make(map[string]Struct)
+
+	scope := p.pkg.Scope()
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		if !obj.Exported() {
+			continue
+		}
+
+		switch obj := obj.(type) {
+		case *types.Const:
+			p.addConst(obj)
+
+		case *types.Var:
+			p.addVar(obj)
+
+		case *types.Func:
+			funcs[name], err = newFunc(p, obj)
+			if err != nil {
+				return err
+			}
+
+		case *types.TypeName:
+			named := obj.Type().(*types.Named)
+			switch typ := named.Underlying().(type) {
+			case *types.Struct:
+				structs[name], err = newStruct(p, obj, typ)
+				if err != nil {
+					return err
+				}
+
+			default:
+				//TODO(sbinet)
+				panic(fmt.Errorf("not yet supported: %v (%T)", typ, obj))
+			}
+
+		default:
+			//TODO(sbinet)
+			panic(fmt.Errorf("not yet supported: %v (%T)", obj, obj))
+		}
+
+	}
+
+	// remove ctors from funcs.
+	// add methods.
+	for sname, s := range structs {
+		for name, fct := range funcs {
+			if fct.ret == nil {
+				continue
+			}
+			if fct.ret == s.obj.Type() {
+				delete(funcs, name)
+				s.ctors = append(s.ctors, fct)
+				structs[sname] = s
+			}
+		}
+
+		ptyp := types.NewPointer(s.obj.Type())
+		mset := types.NewMethodSet(ptyp)
+		for i := 0; i < mset.Len(); i++ {
+			meth := mset.At(i)
+			if !meth.Obj().Exported() {
+				continue
+			}
+			m, err := newMethod(p, &s, meth)
+			if err != nil {
+				return err
+			}
+			s.meths = append(s.meths, m)
+		}
+		p.structs = append(p.structs, s)
+	}
+
+	for _, fct := range funcs {
+		p.funcs = append(p.funcs, fct)
+	}
+
+	return err
+}
+
+func (p *Package) addConst(obj *types.Const) {
+	//TODO(sbinet)
+	panic(fmt.Errorf("not yet supported: %v (%T)", obj, obj))
+}
+
+func (p *Package) addVar(obj *types.Var) {
+	//TODO(sbinet)
+	panic(fmt.Errorf("not yet supported: %v (%T)", obj, obj))
+}
+
+// Struct collects informations about a go struct.
+type Struct struct {
+	obj *types.TypeName
+	typ *types.Struct
+
+	id    string
+	doc   string
+	ctors []Func
+	meths []Method
+}
+
+func newStruct(p *Package, obj *types.TypeName, typ *types.Struct) (Struct, error) {
+	s := Struct{
+		obj: obj,
+		typ: typ,
+		id:  obj.Pkg().Name() + "_" + obj.Name(),
+		doc: p.getDoc("", obj),
+	}
+	return s, nil
+}
+
+// Method collects informations about a go method.
+type Method struct {
+	sel *types.Selection
+
+	id  string
+	doc string
+	ret types.Type // return type, if any
+	err bool       // true if original go method has comma-error
+}
+
+func newMethod(p *Package, typ *Struct, sel *types.Selection) (Method, error) {
+	haserr := false
+	sig := sel.Type().(*types.Signature)
+	res := sig.Results()
+	var ret types.Type
+
+	switch res.Len() {
+	case 2:
+		if !isErrorType(res.At(1).Type()) {
+			return Method{}, fmt.Errorf(
+				"bind: second result value must be of type error: %s",
+				sel,
+			)
+		}
+		haserr = true
+		ret = res.At(0).Type()
+
+	case 1:
+		if isErrorType(res.At(0).Type()) {
+			haserr = true
+			ret = nil
+		} else {
+			ret = res.At(0).Type()
+		}
+	case 0:
+		ret = nil
+	default:
+		return Method{}, fmt.Errorf("bind: too many results to return: %v", sel)
+	}
+
+	return Method{
+		sel: sel,
+		id:  typ.obj.Pkg().Name() + "_" + typ.obj.Name() + "_" + sel.Obj().Name(),
+		doc: p.getDoc(typ.obj.Name(), sel.Obj()),
+		ret: ret,
+		err: haserr,
+	}, nil
+
+}
+
+// Func collects informations about a go func.
+type Func struct {
+	typ *types.Func
+
+	id  string
+	doc string
+	ret types.Type // return type, if any
+	err bool       // true if original go func has comma-error
+}
+
+func newFunc(p *Package, obj *types.Func) (Func, error) {
+	haserr := false
+	sig := obj.Type().(*types.Signature)
+	res := sig.Results()
+	var ret types.Type
+
+	switch res.Len() {
+	case 2:
+		if !isErrorType(res.At(1).Type()) {
+			return Func{}, fmt.Errorf(
+				"bind: second result value must be of type error: %s",
+				obj,
+			)
+		}
+		haserr = true
+		ret = res.At(0).Type()
+
+	case 1:
+		if isErrorType(res.At(0).Type()) {
+			haserr = true
+			ret = nil
+		} else {
+			ret = res.At(0).Type()
+		}
+	case 0:
+		ret = nil
+	default:
+		return Func{}, fmt.Errorf("bind: too many results to return: %v", obj)
+	}
+
+	return Func{
+		typ: obj,
+		id:  obj.Pkg().Name() + "_" + obj.Name(),
+		doc: p.getDoc("", obj),
+		ret: ret,
+		err: haserr,
+	}, nil
+}

--- a/bind/package.go
+++ b/bind/package.go
@@ -26,8 +26,9 @@ type Package struct {
 // NewPackage creates a new Package, tying types.Package and ast.Package together.
 func NewPackage(pkg *types.Package, doc *doc.Package) (*Package, error) {
 	p := &Package{
-		pkg: pkg,
-		doc: doc,
+		pkg:  pkg,
+		doc:  doc,
+		objs: map[string]Object{},
 	}
 	err := p.process()
 	if err != nil {
@@ -211,11 +212,11 @@ func (p *Package) process() error {
 			}
 			s.meths = append(s.meths, m)
 		}
-		p.structs = append(p.structs, s)
+		p.addStruct(s)
 	}
 
 	for _, fct := range funcs {
-		p.funcs = append(p.funcs, fct)
+		p.addFunc(fct)
 	}
 
 	return err
@@ -229,6 +230,22 @@ func (p *Package) addConst(obj *types.Const) {
 func (p *Package) addVar(obj *types.Var) {
 	//TODO(sbinet)
 	panic(fmt.Errorf("not yet supported: %v (%T)", obj, obj))
+}
+
+func (p *Package) addStruct(s Struct) {
+	p.structs = append(p.structs, s)
+	p.objs[s.GoName()] = s
+}
+
+func (p *Package) addFunc(f Func) {
+	p.funcs = append(p.funcs, f)
+	p.objs[f.GoName()] = f
+}
+
+// Lookup returns the bind.Object corresponding to a types.Object
+func (p *Package) Lookup(o types.Object) (Object, bool) {
+	obj, ok := p.objs[o.Name()]
+	return obj, ok
 }
 
 // Struct collects informations about a go struct.

--- a/bind/package.go
+++ b/bind/package.go
@@ -18,6 +18,7 @@ type Package struct {
 	pkg *types.Package
 	doc *doc.Package
 
+	objs    map[string]Object
 	structs []Struct
 	funcs   []Func
 }
@@ -271,7 +272,7 @@ func (s Struct) GoName() string {
 	return s.obj.Name()
 }
 
-func (s Struct) Obj() types.Object {
+func (s Struct) GoObj() types.Object {
 	return s.obj
 }
 
@@ -351,7 +352,7 @@ func (f Func) GoName() string {
 	return f.obj.Name()
 }
 
-func (f Func) Obj() types.Object {
+func (f Func) GoObj() types.Object {
 	return f.obj
 }
 

--- a/bind/package.go
+++ b/bind/package.go
@@ -387,12 +387,16 @@ func newFuncFrom(p *Package, parent string, obj types.Object, sig *types.Signatu
 		return Func{}, fmt.Errorf("bind: too many results to return: %v", obj)
 	}
 
+	id := obj.Pkg().Name() + "_" + obj.Name()
+	if parent != "" {
+		id = obj.Pkg().Name() + "_" + parent + "_" + obj.Name()
+	}
 	return Func{
 		pkg:  p,
 		sig:  newSignatureFrom(p, sig),
 		typ:  obj.Type(),
 		name: obj.Name(),
-		id:   obj.Pkg().Name() + "_" + obj.Name(),
+		id:   id,
 		doc:  p.getDoc(parent, obj),
 		ret:  ret,
 		err:  haserr,

--- a/bind/printer.go
+++ b/bind/printer.go
@@ -25,6 +25,10 @@ func (p *printer) writeIndent() error {
 	return err
 }
 
+func (p *printer) Read(b []byte) (n int, err error) {
+	return p.buf.Read(b)
+}
+
 func (p *printer) Write(b []byte) (n int, err error) {
 	wrote := 0
 	for len(b) > 0 {

--- a/bind/printer_test.go
+++ b/bind/printer_test.go
@@ -1,0 +1,57 @@
+// Copyright 2015 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bind
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestPrinter(t *testing.T) {
+	decl := &printer{
+		buf:        new(bytes.Buffer),
+		indentEach: []byte("\t"),
+	}
+
+	impl := &printer{
+		buf:        new(bytes.Buffer),
+		indentEach: []byte("\t"),
+	}
+
+	decl.Printf("\ndecl 1\n")
+	decl.Indent()
+	decl.Printf(">>> decl-1\n")
+	decl.Outdent()
+	impl.Printf("impl 1\n")
+	decl.Printf("decl 2\n")
+	impl.Printf("impl 2\n")
+
+	out := new(bytes.Buffer)
+	_, err := io.Copy(out, decl)
+	if err != nil {
+		t.Fatalf("error: %v\n", err)
+	}
+
+	_, err = io.Copy(out, impl)
+	if err != nil {
+		t.Fatalf("error: %v\n", err)
+	}
+
+	want := `
+decl 1
+	>>> decl-1
+decl 2
+impl 1
+impl 2
+`
+
+	str := string(out.Bytes())
+	if !reflect.DeepEqual(str, want) {
+		t.Fatalf("error:\nwant=%q\ngot =%q\n", want, str)
+	}
+
+}

--- a/bind/types.go
+++ b/bind/types.go
@@ -13,7 +13,6 @@ type Object interface {
 	ID() string
 	Doc() string
 	GoName() string
-	GoObj() types.Object
 }
 
 type Type interface {

--- a/bind/types.go
+++ b/bind/types.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Type interface {
+	Package() *Package
 	GoType() types.Type
 	GoName() string
 	ID() string

--- a/bind/types.go
+++ b/bind/types.go
@@ -5,6 +5,8 @@
 package bind
 
 import (
+	"reflect"
+
 	"golang.org/x/tools/go/types"
 )
 
@@ -74,6 +76,28 @@ type typedesc struct {
 	cgotype string
 	pyfmt   string
 	pysig   string
+}
+
+var (
+	intsize = reflect.TypeOf(int(0)).Size()
+)
+
+func init() {
+	if intsize == 8 {
+		typedescr[types.Int] = typedesc{
+			ctype:   "int64_t",
+			cgotype: "GoInt",
+			pyfmt:   "k",
+			pysig:   "int",
+		}
+
+		typedescr[types.Uint] = typedesc{
+			ctype:   "uint64_t",
+			cgotype: "GoUint",
+			pyfmt:   "K",
+			pysig:   "int",
+		}
+	}
 }
 
 var typedescr = map[types.BasicKind]typedesc{

--- a/bind/types.go
+++ b/bind/types.go
@@ -13,7 +13,7 @@ type Object interface {
 	ID() string
 	Doc() string
 	GoName() string
-	Obj() types.Object
+	GoObj() types.Object
 }
 
 type Type interface {

--- a/bind/types.go
+++ b/bind/types.go
@@ -8,13 +8,17 @@ import (
 	"golang.org/x/tools/go/types"
 )
 
-type Type interface {
+type Object interface {
 	Package() *Package
-	GoType() types.Type
-	GoName() string
 	ID() string
 	Doc() string
+	GoName() string
 	Obj() types.Object
+}
+
+type Type interface {
+	Object
+	GoType() types.Type
 }
 
 func needWrapType(typ types.Type) bool {

--- a/bind/types.go
+++ b/bind/types.go
@@ -8,6 +8,14 @@ import (
 	"golang.org/x/tools/go/types"
 )
 
+type Type interface {
+	GoType() types.Type
+	GoName() string
+	ID() string
+	Doc() string
+	Obj() types.Object
+}
+
 func needWrapType(typ types.Type) bool {
 	switch typ.(type) {
 	case *types.Struct:

--- a/bind/utils.go
+++ b/bind/utils.go
@@ -1,0 +1,13 @@
+// Copyright 2015 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bind
+
+import (
+	"golang.org/x/tools/go/types"
+)
+
+func isErrorType(typ types.Type) bool {
+	return typ == types.Universe.Lookup("error").Type()
+}

--- a/bind/utils.go
+++ b/bind/utils.go
@@ -11,3 +11,35 @@ import (
 func isErrorType(typ types.Type) bool {
 	return typ == types.Universe.Lookup("error").Type()
 }
+
+func isStringer(obj types.Object) bool {
+	switch obj := obj.(type) {
+	case *types.Func:
+		if obj.Name() != "String" {
+			return false
+		}
+		sig, ok := obj.Type().(*types.Signature)
+		if !ok {
+			return false
+		}
+		if sig.Recv() == nil {
+			return false
+		}
+		if sig.Params().Len() != 0 {
+			return false
+		}
+		res := sig.Results()
+		if res.Len() != 1 {
+			return false
+		}
+		ret := res.At(0).Type()
+		if ret != types.Universe.Lookup("string").Type() {
+			return false
+		}
+		return true
+	default:
+		return false
+	}
+
+	return false
+}

--- a/bind/vars.go
+++ b/bind/vars.go
@@ -15,7 +15,7 @@ type Var struct {
 	id    string
 	doc   string
 	name  string
-	obj   types.Object
+	typ   types.Type
 	dtype typedesc
 }
 
@@ -23,14 +23,14 @@ func (v *Var) Name() string {
 	return v.name
 }
 
-func newVar(p *Package, obj types.Object, name, doc string) *Var {
+func newVar(p *Package, typ types.Type, objname, name, doc string) *Var {
 	return &Var{
 		pkg:   p,
-		id:    p.Name() + "_" + obj.Name(),
+		id:    p.Name() + "_" + objname,
 		doc:   doc,
 		name:  name,
-		obj:   obj,
-		dtype: getTypedesc(obj.Type()),
+		typ:   typ,
+		dtype: getTypedesc(typ),
 	}
 }
 
@@ -43,7 +43,7 @@ func newVarsFrom(p *Package, tuple *types.Tuple) []*Var {
 }
 
 func newVarFrom(p *Package, v *types.Var) *Var {
-	return newVar(p, v, v.Name(), p.getDoc("", v))
+	return newVar(p, v.Type(), v.Name(), v.Name(), p.getDoc("", v))
 }
 
 func getTypedesc(t types.Type) typedesc {
@@ -75,7 +75,7 @@ func getTypedesc(t types.Type) typedesc {
 }
 
 func (v *Var) GoType() types.Type {
-	return v.obj.Type()
+	return v.typ
 }
 
 func (v *Var) CType() string {

--- a/bind/vars.go
+++ b/bind/vars.go
@@ -40,9 +40,12 @@ func getTypedesc(t types.Type) typedesc {
 	case *types.Named:
 		switch typ.Underlying().(type) {
 		case *types.Struct:
+			obj := typ.Obj()
+			pkgname := obj.Pkg().Name()
+			id := pkgname + "_" + obj.Name()
 			return typedesc{
-				ctype:   "GoPy_" + typ.Obj().Name(),
-				cgotype: "GoPy_" + typ.Obj().Name(),
+				ctype:   "GoPy_" + id,
+				cgotype: "GoPy_" + id,
 				pyfmt:   "N",
 			}
 		}

--- a/bind/vars.go
+++ b/bind/vars.go
@@ -64,6 +64,14 @@ func getTypedesc(t types.Type) typedesc {
 				cgotype: "GoPy_" + id,
 				pyfmt:   "N",
 			}
+		case *types.Interface:
+			return typedesc{
+				ctype:   "GoInterface",
+				cgotype: "GoInterface",
+				pyfmt:   "?",
+			}
+		default:
+			panic(fmt.Errorf("unhandled type: %#v", typ))
 		}
 	case *types.Pointer:
 		elem := typ.Elem()

--- a/bind/vars.go
+++ b/bind/vars.go
@@ -86,6 +86,15 @@ func (v *Var) genDecl(g *printer) {
 	g.Printf("%[1]s c_%[2]s;\n", v.CGoType(), v.Var.Name())
 }
 
+func (v *Var) genRecvDecl(g *printer) {
+	g.Printf("%[1]s c_%[2]s;\n", v.CGoType(), v.Var.Name())
+}
+
+func (v *Var) genRecvImpl(g *printer) {
+	n := string(v.CGoType()[len("GoPy_"):])
+	g.Printf("c_%[1]s = ((_gopy_%[2]s*)self)->cgopy;\n", v.Var.Name(), n)
+}
+
 func (v *Var) genRetDecl(g *printer) {
 	if v.isGoString() {
 		g.Printf("const char* cgopy_gopy_ret;\n")

--- a/gen.go
+++ b/gen.go
@@ -165,5 +165,5 @@ func newPackage(files []*ast.File, conf *loader.Config, pkg *build.Package) (*bi
 
 	pkgdoc := doc.New(pkgast, pkg.ImportPath, 0)
 
-	return bind.NewPackage(p, pkgdoc), err
+	return bind.NewPackage(p, pkgdoc)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -80,6 +80,7 @@ Person is a simple struct
 
 --- p = hi.Person()...
 ['Age', 'Greet', 'Name', 'String', '__class__', '__delattr__', '__doc__', '__format__', '__getattribute__', '__hash__', '__init__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__']
+--- p: hi.Person{Name="", Age=0}
 --- p.Name: 
 --- p.Age: 0
 --- doc(hi.Greet):

--- a/main_test.go
+++ b/main_test.go
@@ -51,6 +51,9 @@ func TestBind(t *testing.T) {
 
 	want := []byte(`hi from go
 hello you from go
+working...
+worked for 2 hours
+working...
 --- doc(hi)...
 package hi exposes a few Go functions to be wrapped and used from Python.
 
@@ -79,7 +82,7 @@ Add returns the sum of its arguments.
 Person is a simple struct
 
 --- p = hi.Person()...
-['Age', 'Greet', 'Name', 'String', '__class__', '__delattr__', '__doc__', '__format__', '__getattribute__', '__hash__', '__init__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__']
+['Age', 'Greet', 'Name', 'String', 'Work', '__class__', '__delattr__', '__doc__', '__format__', '__getattribute__', '__hash__', '__init__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__']
 --- p: hi.Person{Name="", Age=0}
 --- p.Name: 
 --- p.Age: 0
@@ -101,6 +104,9 @@ Person is a simple struct
 hi.Person{Name="foo", Age=42}
 --- p.Age: 42
 --- p.Name: foo
+--- p.Work(2)...
+--- p.Work(24)...
+caught: can't work for 24 hours!
 `)
 	buf := new(bytes.Buffer)
 	cmd = exec.Command("python2", "./test.py")

--- a/main_test.go
+++ b/main_test.go
@@ -80,8 +80,8 @@ Person is a simple struct
 
 --- p = hi.Person()...
 ['Age', 'Greet', 'Name', 'String', '__class__', '__delattr__', '__doc__', '__format__', '__getattribute__', '__hash__', '__init__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__']
---- p.Name: None
---- p.Age: None
+--- p.Name: 
+--- p.Age: 0
 --- doc(hi.Greet):
 Greet() str
 
@@ -94,6 +94,12 @@ hi.Person{Name="", Age=0}
 --- doc(p):
 Person is a simple struct
 
+--- p.Name = "foo"...
+--- p.Age = 42...
+--- p.String()...
+hi.Person{Name="foo", Age=42}
+--- p.Age: 42
+--- p.Name: foo
 `)
 	buf := new(bytes.Buffer)
 	cmd = exec.Command("python2", "./test.py")

--- a/main_test.go
+++ b/main_test.go
@@ -89,6 +89,8 @@ Greet sends greetings
 
 --- p.Greet()...
 Hello, I am 
+--- p.String()...
+hi.Person{Name="", Age=0}
 --- doc(p):
 Person is a simple struct
 

--- a/main_test.go
+++ b/main_test.go
@@ -88,7 +88,7 @@ Greet() str
 Greet sends greetings
 
 --- p.Greet()...
-None
+Hello, I am 
 --- doc(p):
 Person is a simple struct
 

--- a/main_test.go
+++ b/main_test.go
@@ -82,6 +82,13 @@ Person is a simple struct
 ['Age', 'Greet', 'Name', 'String', '__class__', '__delattr__', '__doc__', '__format__', '__getattribute__', '__hash__', '__init__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__']
 --- p.Name: None
 --- p.Age: None
+--- doc(hi.Greet):
+Greet() str
+
+Greet sends greetings
+
+--- p.Greet()...
+None
 --- doc(p):
 Person is a simple struct
 

--- a/main_test.go
+++ b/main_test.go
@@ -5,10 +5,12 @@
 package main
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -47,13 +49,60 @@ func TestBind(t *testing.T) {
 		t.Fatalf("error copying 'test.py': %v\n", err)
 	}
 
+	want := []byte(`hi from go
+hello you from go
+--- doc(hi)...
+package hi exposes a few Go functions to be wrapped and used from Python.
+
+--- doc(hi.Hi)...
+Hi() 
+
+Hi prints hi from Go
+
+--- hi.Hi()...
+--- doc(hi.Hello)...
+Hello(str s) 
+
+Hello prints a greeting from Go
+
+--- hi.Hello('you')...
+--- doc(hi.Add)...
+Add(int i, int j) int
+
+Add returns the sum of its arguments.
+
+--- hi.Add(1, 41)...
+42
+--- hi.Concat('4', '2')...
+42
+--- doc(hi.Person):
+Person is a simple struct
+
+--- p = hi.Person()...
+['Age', 'Greet', 'Name', 'String', '__class__', '__delattr__', '__doc__', '__format__', '__getattribute__', '__hash__', '__init__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__']
+--- p.Name: None
+--- p.Age: None
+--- doc(p):
+Person is a simple struct
+
+`)
+	buf := new(bytes.Buffer)
 	cmd = exec.Command("python2", "./test.py")
 	cmd.Dir = workdir
 	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = buf
+	cmd.Stderr = buf
 	err = cmd.Run()
 	if err != nil {
-		t.Fatal("error running python module: %v\n", err)
+		t.Fatalf(
+			"error running python module: %v\n%v\n", err,
+			string(buf.Bytes()),
+		)
+	}
+
+	if !reflect.DeepEqual(string(buf.Bytes()), string(want)) {
+		t.Fatalf("error running python module:\nwant:\n%s\n\ngot:\n%s\n",
+			string(want), string(buf.Bytes()),
+		)
 	}
 }


### PR DESCRIPTION
- rationalize cpython type strings
- generate cgo stub functions, calling structs methods
- generate (invalid) bodyless cpython functions for struct methods

fixes #3
fixes #4 
