### PR TITLE
bind: support for cross-ref gc

### DIFF
--- a/_examples/hi/test.py
+++ b/_examples/hi/test.py
@@ -123,3 +123,21 @@ c.P1.Name = "mom"
 c.P2.Age = 51
 print c
 
+### test gc
+print "--- testing GC..."
+NMAX = 100000
+objs = []
+for i in range(NMAX):
+    p1  = hi.NewPerson("p1-%d" % i, i)
+    p2 = hi.NewPerson("p2-%d" % i, i)
+    objs.append(hi.NewCouple(p1,p2))
+    pass
+print "--- len(objs):",len(objs)
+vs = []
+for i,o in enumerate(objs):
+    v = "%d: %s" % (i, o)
+    vs.append(v)
+    pass
+print "--- len(vs):",len(vs)
+del objs
+print "--- testing GC... [ok]"

--- a/bind/gencpy.go
+++ b/bind/gencpy.go
@@ -448,6 +448,7 @@ func (g *cpyGen) genStructDealloc(cpy Struct) {
 		cpy.ID(),
 	)
 	g.impl.Indent()
+	g.impl.Printf("cgopy_decref((GoPy_%[1]s)(self->cgopy));\n", cpy.ID())
 	g.impl.Printf("self->ob_type->tp_free((PyObject*)self);\n")
 	g.impl.Outdent()
 	g.impl.Printf("}\n\n")

--- a/main_test.go
+++ b/main_test.go
@@ -133,6 +133,10 @@ hi.Couple{P1=hi.Person{Name="", Age=0}, P2=hi.Person{Name="", Age=0}}
 --- c = hi.NewCouple(tom, bob)...
 hi.Couple{P1=hi.Person{Name="tom", Age=50}, P2=hi.Person{Name="bob", Age=41}}
 hi.Couple{P1=hi.Person{Name="mom", Age=50}, P2=hi.Person{Name="bob", Age=51}}
+--- testing GC...
+--- len(objs): 100000
+--- len(vs): 100000
+--- testing GC... [ok]
 `)
 	buf := new(bytes.Buffer)
 	cmd = exec.Command("python2", "./test.py")


### PR DESCRIPTION
This CL implements a ref-counting scheme for go values passed to the python
world.
Go values (actually, their unsafe.Pointer) are associated with a reference
counter as soon as they exit the Go world.
These values are also pinned inside a global map to prevent the GC from moving
them around.
Conversely, python objects wrapping Go values will decrease the reference
counter when the __del__ method is called.

Fixes #7

Change-Id: I9b6434d0933b7abe409ac130f3a8c0655c1f23a9