### PR TITLE
bind: starting support for maps in go

### DIFF
--- a/_examples/maps/maps.go
+++ b/_examples/maps/maps.go
@@ -1,0 +1,17 @@
+// Copyright 2015 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package maps
+
+
+func MapsFunc(t map[string]int) {
+
+}
+
+func MapsFunc2() map[int]string {
+	return map[int]string{
+		1 : "hello",
+		2 : "world",
+	}
+}

--- a/bind/gencpy_type.go
+++ b/bind/gencpy_type.go
@@ -324,6 +324,14 @@ func (g *cpyGen) genTypeInit(sym *symbol) {
 		g.impl.Outdent()
 		g.impl.Printf("}\n\n") // if-arg
 
+
+	case sym.isMap():
+		g.impl.Printf("if (arg != NULL) {\n")
+		g.impl.Indent()
+		//g.impl.Printf("//put map __init__ functions here")
+		g.impl.Outdent()
+		g.impl.Printf("}\n\n") // if-arg
+
 	case sym.isSignature():
 		//TODO(sbinet)
 

--- a/bind/types.go
+++ b/bind/types.go
@@ -35,6 +35,8 @@ func needWrapType(typ types.Type) bool {
 		}
 	case *types.Array:
 		return true
+	case *types.Map:
+		return true
 	case *types.Slice:
 		return true
 	case *types.Interface:


### PR DESCRIPTION
Adding code so that the GO parser will now recognize maps in function declarations. No wrapper methods have been added to make them useable yet. 