### PR TITLE
Ignore private fields in structs

### DIFF
--- a/_examples/wrapper/pywrapper/wrapper_code.go
+++ b/_examples/wrapper/pywrapper/wrapper_code.go
@@ -1,0 +1,24 @@
+// Copyright 2015 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pywrapper
+
+import (
+	"github.com/go-python/gopy/_examples/wrapper"
+	"fmt"
+)
+
+type WrapperStruct struct {
+	data *wrapper.RealStruct
+}
+
+func Test() string {
+	a := wrapper.PointerTest()
+	fmt.Println("%t", a)
+	return "Hello"
+}
+
+func (a WrapperStruct) Test() string {
+	return fmt.Sprintf("%t", a.data)
+}

--- a/_examples/wrapper/real_code.go
+++ b/_examples/wrapper/real_code.go
@@ -1,0 +1,15 @@
+// Copyright 2015 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package wrapper
+
+
+type RealStruct struct {
+	pointers map[string]*RealStruct
+	Channel   chan int
+}
+
+func PointerTest() *RealStruct {
+	return &RealStruct{}
+}

--- a/bind/symtab.go
+++ b/bind/symtab.go
@@ -99,6 +99,10 @@ type symbol struct {
 	pychk string
 }
 
+func isPrivate(s string) bool {
+	return (strings.ToLower(s[0:1]) == s[0:1])
+}
+
 func (s symbol) isType() bool {
 	return (s.kind & skType) != 0
 }
@@ -569,6 +573,7 @@ func (sym *symtab) addStructType(pkg *types.Package, obj types.Object, t types.T
 	kind |= skStruct
 	pybuf := make([]string, 0, typ.NumFields())
 	for i := 0; i < typ.NumFields(); i++ {
+		if isPrivate(typ.Field(i).Name()) { continue }
 		ftyp := typ.Field(i).Type()
 		fsym := sym.symtype(ftyp)
 		if fsym == nil {


### PR DESCRIPTION
In response to issue #60 
This patch adds a check so that the types of private fields aren't exported to the wrapper. This is useful if writing a 'wrapper' package that buffers the python code from complex GO concepts that aren't yet wrapped for python (like pointers and channels). the code `_examples/wrapper/real_code.go` and `_examples/wrapper/python/wrapper_code.go`  can be compiled with the command `gopy bind github.com/go-python/gopy/_examples/wrapper/python`, and the functions manipulate GO classes gopy doesn't yet support, but they are private, and not exported, so now the code will compile.