### PR TITLE
Casting struct arguments to method calls.

### DIFF
--- a/_examples/structs/structs.go
+++ b/_examples/structs/structs.go
@@ -15,6 +15,10 @@ func (S) Upper(s string) string {
 	return strings.ToUpper(s)
 }
 
+func FuncTest(item S) {}
+
+func (this S) MethodTest(item S1) {}
+
 type S1 struct {
 	private int
 }

--- a/bind/gengo.go
+++ b/bind/gengo.go
@@ -440,7 +440,11 @@ func (g *goGen) genMethodBody(s Struct, m Func) {
 		if i+1 < len(args) {
 			tail = ", "
 		}
-		g.Printf("%s%s", arg.Name(), tail)
+		if arg.sym.isStruct() {
+			g.Printf("*(*%s)(unsafe.Pointer(%s))%s", arg.sym.gofmt(), arg.Name(), tail)
+		} else {
+			g.Printf("%s%s", arg.Name(), tail)
+		}
 	}
 	g.Printf(")\n")
 


### PR DESCRIPTION
This is a first attempt to properly cast struct arguments to method calls. The test example would be `func (this S) MethodTest(item S1) {}` from the structs.go example.