### PR TITLE
Add Dockerfile to support docker builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:onbuild
+RUN apt-get update && apt-get install -y pkg-config python2.7-dev && apt-get clean
+CMD /go/bin/app

--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ PASS
 ok  	github.com/go-python/gopy	2.135s
 ```
 
+## Binding generation using Docker (for cross-platform builds)
+
+```
+$ cd github.com/go-python/gopy/_examples/hi
+$ docker run -it --rm -v `pwd`:/go/src/in -v `pwd`:/out xlab/gopy app bind -output=/out in
+$ file hi.so
+hi.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, not stripped
+```
+
+The docker image can also be built on local machine:
+
+```
+$ cd $GOPATH/src/github.com/go-python/gopy
+$ docker build -t go-python/gopy .
+$ docker run -it --rm go-python/gopy
+```
+
 ## Limitations
 
 - wrap `go` structs into `python` classes **[DONE]**

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ ok  	github.com/go-python/gopy	2.135s
 
 ```
 $ cd github.com/go-python/gopy/_examples/hi
-$ docker run -it --rm -v `pwd`:/go/src/in -v `pwd`:/out xlab/gopy app bind -output=/out in
+$ docker run --rm -v `pwd`:/go/src/in -v `pwd`:/out gopy/gopy app bind -output=/out in
 $ file hi.so
 hi.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, not stripped
 ```


### PR DESCRIPTION
Hi, thanks for this great tool. I'd like to make it docker-enabled, so I can produce cpython artefacts for `Linux x86_64` while having `Darwin x86_64` as my primary working environment.

See the `Dockerfile`. Now this repo can be hosted on [docker hub](https://hub.docker.com) or built locally:
```
$ docker build -t go-python/gopy .
```

**Usage example:**
```
$ cd ~/go/src/github.com/go-python/gopy/_examples/hi
$ docker run -it --rm -v `pwd`:/go/src/in -v `pwd`:/out go-python/gopy app bind -output=/out in
$ file hi.so
hi.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, not stripped
```

Works fine without any external deps ever, on any host capable of docker.