### PR TITLE
Increment reference count for results in genMethodBody.

### DIFF
--- a/bind/gengo.go
+++ b/bind/gengo.go
@@ -451,6 +451,13 @@ func (g *goGen) genMethodBody(s Struct, m Func) {
 		return
 	}
 
+	for i, res := range results {
+		if !res.needWrap() {
+			continue
+		}
+		g.Printf("cgopy_incref(unsafe.Pointer(&_gopy_%03d))\n", i)
+	}
+
 	g.Printf("return ")
 	for i, res := range results {
 		if i > 0 {


### PR DESCRIPTION
I think this was a small omission.  `genFuncBody` generates calls to `cgopy_incref` for all of the return values that require reference counts, but `genMethodBody` was missing that logic.  This causes a panic with the message "cgopy: decref untracked object" for Go methods that return objects when those objects are eventually deleted.