### PR TITLE
Fixed bug with SIGSEGV if function returns (string, error)

### DIFF
--- a/_examples/hi/hi.go
+++ b/_examples/hi/hi.go
@@ -38,6 +38,15 @@ func Concat(s1, s2 string) string {
 	return s1 + s2
 }
 
+// LookupQuestion returns question for given answer.
+func LookupQuestion(n int) (string, error) {
+	if n == 42 {
+		return "Life, the Universe and Everything", nil
+	} else {
+		return "", fmt.Errorf("Wrong answer: %v != 42", n)
+	}
+}
+
 // Add returns the sum of its arguments.
 func Add(i, j int) int {
 	return i + j

--- a/_examples/hi/test.py
+++ b/_examples/hi/test.py
@@ -46,6 +46,17 @@ print hi.Add(1,41)
 print "--- hi.Concat('4', '2')..."
 print hi.Concat("4","2")
 
+print "--- hi.LookupQuestion(42)..."
+print hi.LookupQuestion(42)
+
+print "--- hi.LookupQuestion(12)..."
+try:
+    hi.LookupQuestion(12)
+    print "*ERROR* no exception raised!"
+except Exception, err:
+    print "caught:", err
+    pass
+
 print "--- doc(hi.Person):"
 print hi.Person.__doc__
 

--- a/bind/gencpy_func.go
+++ b/bind/gencpy_func.go
@@ -323,7 +323,11 @@ func (g *cpyGen) genFuncBody(f Func) {
 				return
 			}
 			pyfmt, _ := res[0].getArgBuildValue()
-			g.impl.Printf("return Py_BuildValue(%q, c_gopy_ret.r0);\n", pyfmt)
+			if res[0].sym.hasConverter() {
+				g.impl.Printf("return Py_BuildValue(%q, %s, &c_gopy_ret.r0);\n", pyfmt, res[0].sym.c2py)
+			} else {
+				g.impl.Printf("return Py_BuildValue(%q, c_gopy_ret.r0);\n", pyfmt)
+			}
 			return
 
 		default:

--- a/main_test.go
+++ b/main_test.go
@@ -142,6 +142,10 @@ Add returns the sum of its arguments.
 42
 --- hi.Concat('4', '2')...
 42
+--- hi.LookupQuestion(42)...
+Life, the Universe and Everything
+--- hi.LookupQuestion(12)...
+caught: Wrong answer: 12 != 42
 --- doc(hi.Person):
 Person is a simple struct
 


### PR DESCRIPTION
I'm trying out hello worlds and all with Go and Go-Python integration and stumbled upon issue with functions, returning (string, error).

This example fails with SIGSEGV upon call:

```
func NoProblemmo() (string, error) {
    return "No Problemmo!", nil
}
```

Please see commit for details, it's pretty straightforward.