### PR TITLE
bind: make sure GODEBUG=cgocheck=0 for Go>=1.6

### DIFF
--- a/cmd_bind.go
+++ b/cmd_bind.go
@@ -6,14 +6,17 @@ package main
 
 import (
 	"fmt"
+	"github.com/gonuts/commander"
+	"github.com/gonuts/flag"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
-
-	"github.com/gonuts/commander"
-	"github.com/gonuts/flag"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
 )
 
 func gopyMakeCmdBind() *commander.Command {
@@ -48,6 +51,20 @@ func gopyRunCmdBind(cmdr *commander.Command, args []string) error {
 
 	odir := cmdr.Flag.Lookup("output").Value.Get().(string)
 	lang := cmdr.Flag.Lookup("lang").Value.Get().(string)
+
+	version := runtime.Version()
+	major, minor, err := getGoVersion(version)
+	if err != nil {
+		return fmt.Errorf("Failed to get the Go version information.")
+	}
+
+	if major >= 1 && minor >= 6 {
+		godebug := os.Getenv("GODEBUG")
+		cgo_check, err := getCgoCheck(godebug)
+		if err != nil || cgo_check != 0 {
+			return fmt.Errorf("GODEBUG=cgocheck=0 should be set for Go>=1.6")
+		}
+	}
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -154,4 +171,31 @@ func gopyRunCmdBind(cmdr *commander.Command, args []string) error {
 	}
 
 	return err
+}
+
+func getGoVersion(version string) (int64, int64, error) {
+	version_regex := regexp.MustCompile(`^go((\d+)(\.(\d+))*)`)
+	match := version_regex.FindStringSubmatch(version)
+	if match == nil {
+		return -1, -1, fmt.Errorf("Invalid Go version information: %s", version)
+	}
+	version_info := strings.Split(match[1], ".")
+	major, _ := strconv.ParseInt(version_info[0], 10, 0)
+	minor, _ := strconv.ParseInt(version_info[1], 10, 0)
+	return major, minor, nil
+}
+
+func getCgoCheck(godebug string) (int, error) {
+	if godebug != "" {
+		for _, option := range strings.Split(godebug, ",") {
+			if strings.HasPrefix(option, "cgocheck=") {
+				cgocheck, err := strconv.Atoi(option[9:])
+				if err != nil {
+					return -1, fmt.Errorf("Invalid cgocheck: %s", option)
+				}
+				return cgocheck, nil
+			}
+		}
+	}
+	return -1, nil
 }

--- a/cmd_bind_test.go
+++ b/cmd_bind_test.go
@@ -1,0 +1,69 @@
+// Copyright 2015 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestGetGoVersion(t *testing.T) {
+	var versionTests = []struct {
+		info  string
+		major int64
+		minor int64
+		err   error
+	}{
+		{"go1.5", 1, 5, nil},
+		{"go1.6", 1, 6, nil},
+		{"go1.7", 1, 7, nil},
+		{"go1.8", 1, 8, nil},
+		{"gcc4", -1, -1, errors.New("Invalid Go version information: gcc4")},
+		{"1.8go", -1, -1, errors.New("Invalid Go version information: 1.8go")},
+		{"llvm", -1, -1, errors.New("Invalid Go version information: llvm")},
+	}
+
+	for _, tt := range versionTests {
+		major, minor, err := getGoVersion(tt.info)
+		if major != tt.major {
+			t.Errorf("getGoVersion(%s): expected major %d, actual %d", tt.info, tt.major, major)
+		}
+
+		if minor != tt.minor {
+			t.Errorf("getGoVersion(%s): expected major %d, actual %d", tt.info, tt.minor, minor)
+		}
+
+		if err != nil && err.Error() != tt.err.Error() {
+			t.Errorf("getGoVersion(%s): expected err %s, actual %s", tt.info, tt.err, err)
+		}
+	}
+}
+
+func TestGetCgoCheck(t *testing.T) {
+	var cgoTests = []struct {
+		info     string
+		expected int
+		err      error
+	}{
+		{"", -1, nil},
+		{"efence=1", -1, nil},
+		{"asdad", -1, nil},
+		{"efence=1,cgocheck=1", 1, nil},
+		{"efence=1,cgocheck=-1", -1, nil},
+		{"cgocheck=2", 2, nil},
+		{"cgocheck=asda", -1, errors.New("Invalid cgocheck: cgocheck=asda")},
+	}
+
+	for _, tt := range cgoTests {
+		actual, err := getCgoCheck(tt.info)
+		if actual != tt.expected {
+			t.Errorf("getCgoCheck(%s): expected cgocheck %d, actual %d", tt.info, tt.expected, actual)
+		}
+
+		if err != nil && err.Error() != tt.err.Error() {
+			t.Errorf("getCgoCheck(%s): expected err %s, actual %s", tt.info, tt.err, err)
+		}
+	}
+}


### PR DESCRIPTION
https://github.com/go-python/gopy/issues/85

1. Check go version.
2. If go version is great equal than 1.6 then check `cgocheck=1` is set, if not raise the error.