### PR TITLE
gopy,bind: add boilerplate code for cffi support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ go:
   - 1.6.x
   - 1.7.x
   - 1.8.x
+  - master
 
-sudo: false
+sudo: required
 
 before_install:
+   - sudo apt-get install libffi-dev
+   - sudo pip install cffi
    - export PATH=$HOME/gopath/bin:$PATH
    # temporary workaround for go-python/gopy#83
    - export GODEBUG=cgocheck=0

--- a/bind/bind.go
+++ b/bind/bind.go
@@ -53,6 +53,42 @@ func GenCPython(w io.Writer, fset *token.FileSet, pkg *Package, lang int) error 
 	return err
 }
 
+// GenCFFI generates a CFFI package from a Go package
+// Use 4spaces indentation for Python codes, aka PEP8.
+// b is an io.Writer for a builder python script.
+// w is an io.Writer for a wrapper python script which will be executed by a user.
+//
+// GenCFFI generates a builder python script and a wrapper python script by 3 steps.
+// First, GenCFFI analyze which interfaces should be exposed from the Go package.
+// Second, Then GenCFFI writes a CFFI builder package with writing exposed interfaces
+// Third, The GenCFFI writes a wrapper python script.
+func GenCFFI(b io.Writer, w io.Writer, fset *token.FileSet, pkg *Package, lang int) error {
+	gen := &cffiGen{
+		builder: &printer{buf: new(bytes.Buffer), indentEach: []byte("    ")},
+		wrapper: &printer{buf: new(bytes.Buffer), indentEach: []byte("    ")},
+		fset:    fset,
+		pkg:     pkg,
+		lang:    lang,
+	}
+
+	err := gen.gen()
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(b, gen.builder)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(w, gen.wrapper)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
 // GenGo generates a cgo package from a Go package
 func GenGo(w io.Writer, fset *token.FileSet, pkg *Package, lang int) error {
 	buf := new(bytes.Buffer)

--- a/bind/gencffi.go
+++ b/bind/gencffi.go
@@ -1,0 +1,160 @@
+// Copyright 2017 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bind
+
+import (
+	"go/token"
+)
+
+const (
+	/*
+	   FIXME(corona10): ffibuilder.cdef should be written this way.
+	   ffibuilder.cdef("""
+	   	//header exported from 'go tool cgo'
+	   	#include "%[3]s.h"
+	   	""")
+
+	   * discuss: https://github.com/go-python/gopy/pull/93#discussion_r119652220
+	*/
+	builderPreamble = `import os
+
+from sys import argv
+from cffi import FFI
+
+ffibuilder = FFI()
+ffibuilder.set_source(
+    '%[1]s',
+    None,
+    extra_objects=["_%[1]s.so"],
+)
+
+ffibuilder.cdef("""
+typedef signed char GoInt8;
+typedef unsigned char GoUint8;
+typedef short GoInt16;
+typedef unsigned short GoUint16;
+typedef int GoInt32;
+typedef unsigned int GoUint32;
+typedef long long GoInt64;
+typedef size_t GoUintptr;
+typedef unsigned long long GoUint64;
+typedef GoInt64 GoInt;
+typedef GoUint64 GoUint;
+typedef float GoFloat32;
+typedef double GoFloat64;
+typedef struct { const char *p; GoInt n; } GoString;
+typedef void *GoMap;
+typedef void *GoChan;
+typedef struct { void *t; void *v; } GoInterface;
+typedef struct { void *data; GoInt len; GoInt cap; } GoSlice;
+
+extern GoString _cgopy_GoString(char* p0);
+extern char* _cgopy_CString(GoString p0);
+extern GoUint8 _cgopy_ErrorIsNil(GoInterface p0);
+extern char* _cgopy_ErrorString(GoInterface p0);
+extern void cgopy_incref(void* p0);
+extern void cgopy_decref(void* p0);
+
+extern void cgo_pkg_%[1]s_init();
+
+`
+	builderPreambleEnd = `""")
+
+if __name__ == "__main__":
+    ffibuilder.compile()
+    # Remove itself after compile.
+    os.remove(argv[0])
+`
+
+	cffiPreamble = `
+__doc__="""%[1]s"""
+
+import os
+
+# python <--> cffi helper.
+class _cffi_helper(object):
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    lib = ffi.dlopen(os.path.join(here, "_%[2]s.so"))
+
+    @staticmethod
+    def cffi_cnv_py2c_string(o):
+        s = ffi.new("char[]", o)
+        return _cffi_helper.lib._cgopy_GoString(s)
+
+    @staticmethod
+    def cffi_cnv_py2c_int(o):
+        return ffi.cast('int', o)
+
+    @staticmethod
+    def cffi_cnv_py2c_float32(o):
+        return ffi.cast('float', o)
+
+    @staticmethod
+    def cffi_cnv_py2c_float64(o):
+        return ffi.cast('double', o)
+
+    @staticmethod
+    def cffi_cnv_c2py_string(c):
+        s = _cffi_helper.lib._cgopy_CString(c)
+        return ffi.string(s)
+
+    @staticmethod
+    def cffi_cnv_c2py_int(c):
+        return int(c)
+
+    @staticmethod
+    def cffi_cnv_c2py_float32(c):
+        return float(c)
+
+    @staticmethod
+    def cffi_cnv_c2py_float64(c):
+        return float(c)
+
+# make sure Cgo is loaded and initialized
+_cffi_helper.lib.cgo_pkg_%[2]s_init()
+`
+)
+
+type cffiGen struct {
+	builder *printer
+	wrapper *printer
+
+	fset *token.FileSet
+	pkg  *Package
+	err  ErrorList
+
+	lang int // c-python api version (2,3)
+}
+
+func (g *cffiGen) gen() error {
+	// Write preamble for CFFI builder.py
+	g.genBuilderPreamble()
+	// Write preamble for CFFI library wrapper.
+	g.genCffiPreamble()
+	for _, f := range g.pkg.funcs {
+		g.genFunc(f)
+		g.genCdef(f)
+	}
+
+	// Finalizing preamble for CFFI builder.py
+	g.genBuilderPreambleEnd()
+	return nil
+}
+
+func (g *cffiGen) genBuilderPreamble() {
+	n := g.pkg.pkg.Name()
+	g.builder.Printf(builderPreamble, n)
+}
+
+func (g *cffiGen) genBuilderPreambleEnd() {
+	g.builder.Printf(builderPreambleEnd)
+}
+
+func (g *cffiGen) genCffiPreamble() {
+	n := g.pkg.pkg.Name()
+	pkgDoc := g.pkg.doc.Doc
+	g.wrapper.Printf(cffiPreamble, pkgDoc, n)
+}

--- a/bind/gencffi_cdef.go
+++ b/bind/gencffi_cdef.go
@@ -1,0 +1,35 @@
+// Copyright 2017 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bind
+
+import (
+	"strconv"
+	"strings"
+)
+
+func (g *cffiGen) genCdef(f Func) {
+	var params []string
+	var cdef_ret string
+	sig := f.sig
+	rets := sig.Results()
+
+	switch len(rets) {
+	case 0:
+		cdef_ret = "void"
+	case 1:
+		cdef_ret = rets[0].sym.cgoname
+	default:
+		cdef_ret = "cgo_func_" + f.name + "_return"
+	}
+
+	args := sig.Params()
+	for i := 0; i < len(args); i++ {
+		paramVar := args[i].sym.cgoname + " " + "p" + strconv.Itoa(i)
+		params = append(params, paramVar)
+	}
+
+	paramString := strings.Join(params, ", ")
+	g.builder.Printf("extern %[1]s cgo_func_%[2]s_%[3]s(%[4]s);\n", cdef_ret, g.pkg.Name(), f.name, paramString)
+}

--- a/bind/gencffi_func.go
+++ b/bind/gencffi_func.go
@@ -1,0 +1,66 @@
+// Copyright 2017 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bind
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (g *cffiGen) genFunc(o Func) {
+	sig := o.Signature()
+	args := sig.Params()
+
+	var funcArgs []string
+	for _, arg := range args {
+		funcArgs = append(funcArgs, arg.Name())
+	}
+	g.wrapper.Printf(`
+# pythonization of: %[1]s.%[2]s 
+def %[2]s(%[3]s):
+`,
+		g.pkg.pkg.Name(),
+		o.GoName(),
+		strings.Join(funcArgs, ", "),
+	)
+
+	g.wrapper.Indent()
+	g.genFuncBody(o)
+	g.wrapper.Outdent()
+	g.wrapper.Printf("\n")
+}
+
+func (g *cffiGen) genFuncBody(f Func) {
+	sig := f.Signature()
+	res := sig.Results()
+	args := sig.Params()
+	nres := 0
+
+	var funcArgs []string
+	for _, arg := range args {
+		g.wrapper.Printf("%[1]s = _cffi_helper.cffi_cnv_py2c_%[2]s(%[3]s)\n", arg.getFuncArg(), arg.GoType(), arg.Name())
+		funcArgs = append(funcArgs, arg.getFuncArg())
+	}
+
+	if res != nil {
+		nres = len(res)
+		if nres > 0 {
+			g.wrapper.Printf("cret = ")
+		}
+	}
+
+	g.wrapper.Printf("_cffi_helper.lib.cgo_func_%[1]s_%[2]s(%[3]s)\n", g.pkg.Name(), f.name, strings.Join(funcArgs, ", "))
+
+	switch nres {
+	case 0:
+		// no-op
+	case 1:
+		ret := res[0]
+		g.wrapper.Printf("ret = _cffi_helper.cffi_cnv_c2py_%[1]s(cret)\n", ret.GoType())
+		g.wrapper.Printf("return ret\n")
+	default:
+		panic(fmt.Errorf("gopy: Not yet implemeted for multiple return."))
+	}
+}

--- a/gen.go
+++ b/gen.go
@@ -54,6 +54,30 @@ func genPkg(odir string, p *bind.Package, lang string) error {
 	}
 
 	switch lang {
+	case "cffi":
+		o, err = os.Create(filepath.Join(odir, p.Name()+".py"))
+		if err != nil {
+			return err
+		}
+		defer o.Close()
+
+		// File for builder.py
+		var b *os.File
+		b, err = os.Create(filepath.Join(odir, "build_"+p.Name()+".py"))
+		if err != nil {
+			return err
+		}
+		defer b.Close()
+		err = bind.GenCFFI(b, o, fset, p, 2)
+		if err != nil {
+			return err
+		}
+
+		err = b.Close()
+		if err != nil {
+			return err
+		}
+
 	case "python2", "py2":
 		o, err = os.Create(filepath.Join(odir, p.Name()+".c"))
 		if err != nil {


### PR DESCRIPTION
* gopy/gen.go: Add a new "cffi" language switch
* gopy/cmd_bind.go: Reduce to using cmd copy command.
* gopy/bind/gencffi.go: Add a new cffiGen type, modeled after cpyGen.
* gopy/bind/gencffi_cdef.go: Expose CAPI generated by cgo for CFFI.
* gopy/bind/gencffi_func.go: Generate CFFI wrapped functions.
* gopy/gen.go: Generate a CFFI builder python file and a wrapping CFFI python file.
* goby/main_test.go: Add test case for CFFI with simple.go.

Fixes go-python/gopy#48, go-python/gopy#87