### PR TITLE
Gofmt check

### DIFF
--- a/_examples/wrapper/pywrapper/wrapper_code.go
+++ b/_examples/wrapper/pywrapper/wrapper_code.go
@@ -6,6 +6,7 @@ package pywrapper
 
 import (
 	"fmt"
+
 	"github.com/go-python/gopy/_examples/wrapper"
 )
 

--- a/bind/gengo.go
+++ b/bind/gengo.go
@@ -17,7 +17,7 @@ const (
 	"strings"
 	"os"
 `
-	checkGoVersion= "_cgopy_CheckGoVersion()"
+	checkGoVersion    = "_cgopy_CheckGoVersion()"
 	checkGoVersionDef = `
 func _cgopy_CheckGoVersion() {
         godebug := os.Getenv("GODEBUG")

--- a/bind/utils.go
+++ b/bind/utils.go
@@ -161,4 +161,4 @@ func getGoVersion(version string) (int64, int64, error) {
 	major, _ := strconv.ParseInt(version_info[0], 10, 0)
 	minor, _ := strconv.ParseInt(version_info[1], 10, 0)
 	return major, minor, nil
- }
+}

--- a/main_test.go
+++ b/main_test.go
@@ -14,6 +14,35 @@ import (
 	"testing"
 )
 
+func TestGofmt(t *testing.T) {
+	exe, err := exec.LookPath("goimports")
+	if err != nil {
+		switch e := err.(type) {
+		case *exec.Error:
+			if e.Err == exec.ErrNotFound {
+				exe, err = exec.LookPath("gofmt")
+			}
+		}
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(exe, "-d", ".")
+	buf := new(bytes.Buffer)
+	cmd.Stdout = buf
+	cmd.Stderr = buf
+
+	err = cmd.Run()
+	if err != nil {
+		t.Fatalf("error running %s:\n%s\n%v", exe, string(buf.Bytes()), err)
+	}
+
+	if len(buf.Bytes()) != 0 {
+		t.Errorf("some files were not gofmt'ed:\n%s\n", string(buf.Bytes()))
+	}
+}
+
 type pkg struct {
 	path string
 	want []byte


### PR DESCRIPTION
This CL adds a test to make sure we always correctly `gofmt` our code (actually, if `goimports` is available, we run it instead of `gofmt`)