### PR TITLE
gencffi: Detect functions returning a Go error

### DIFF
--- a/_examples/pyerrors/pyerrors.go
+++ b/_examples/pyerrors/pyerrors.go
@@ -1,0 +1,16 @@
+// Copyright 2017 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package pyerrors holds functions returning an error.
+package pyerrors
+
+import "errors"
+
+// Div is a function for detecting errors.
+func Div(i, j int) (int, error) {
+	if j == 0 {
+		return 0, errors.New("Divide by zero.")
+	}
+	return i / j, nil
+}

--- a/_examples/pyerrors/test.py
+++ b/_examples/pyerrors/test.py
@@ -1,0 +1,18 @@
+# Copyright 2017 The go-python Authors.  All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+## py2/py3 compat
+from __future__ import print_function
+
+import pyerrors
+
+def div(a, b):
+    try:
+        r = pyerrors.Div(a, b)
+        print("pyerrors.Div(%d, %d) = %d"% (a, b, r))
+    except Exception as e:
+        print(str(e))
+
+div(5,0)
+div(5,2)

--- a/bind/gencffi.go
+++ b/bind/gencffi.go
@@ -42,6 +42,7 @@ typedef struct { void *data; GoInt len; GoInt cap; } GoSlice;
 
 extern GoString _cgopy_GoString(char* p0);
 extern char* _cgopy_CString(GoString p0);
+extern void _cgopy_FreeCString(char* p0);
 extern GoUint8 _cgopy_ErrorIsNil(GoInterface p0);
 extern char* _cgopy_ErrorString(GoInterface p0);
 extern void cgopy_incref(void* p0);
@@ -81,7 +82,9 @@ class _cffi_helper(object):
     @staticmethod
     def cffi_cgopy_cnv_c2py_string(c):
         s = _cffi_helper.lib._cgopy_CString(c)
-        return ffi.string(s)
+        pystr = ffi.string(s)
+        _cffi_helper.lib._cgopy_FreeCString(s)
+        return pystr
 
     @staticmethod
     def cffi_cgopy_cnv_c2py_int(c):
@@ -98,6 +101,7 @@ class _cffi_helper(object):
     @staticmethod
     def cffi_cgopy_cnv_c2py_uint(c):
         return int(c)
+
 # make sure Cgo is loaded and initialized
 _cffi_helper.lib.cgo_pkg_%[1]s_init()
 `

--- a/bind/gencffi_cdef.go
+++ b/bind/gencffi_cdef.go
@@ -32,9 +32,11 @@ func (g *cffiGen) genCdefType(sym *symbol) {
 
 func (g *cffiGen) genCdefFunc(f Func) {
 	var params []string
+	var retParams []string
 	var cdef_ret string
 	sig := f.sig
 	rets := sig.Results()
+	args := sig.Params()
 
 	switch len(rets) {
 	case 0:
@@ -42,15 +44,19 @@ func (g *cffiGen) genCdefFunc(f Func) {
 	case 1:
 		cdef_ret = rets[0].sym.cgoname
 	default:
-		cdef_ret = "cgo_func_" + f.name + "_return"
+		for i := 0; i < len(rets); i++ {
+			retParam := rets[i].sym.cgoname + " r" + strconv.Itoa(i)
+			retParams = append(retParams, retParam)
+		}
+		cdef_ret = "cgo_func_" + f.id + "_return"
+		retParamStrings := strings.Join(retParams, "; ")
+		g.wrapper.Printf("typedef struct { %[1]s; } %[2]s;\n", retParamStrings, cdef_ret)
 	}
 
-	args := sig.Params()
 	for i := 0; i < len(args); i++ {
 		paramVar := args[i].sym.cgoname + " " + "p" + strconv.Itoa(i)
 		params = append(params, paramVar)
 	}
-
 	paramString := strings.Join(params, ", ")
 	g.wrapper.Printf("extern %[1]s cgo_func_%[2]s(%[3]s);\n", cdef_ret, f.id, paramString)
 }

--- a/bind/gengo.go
+++ b/bind/gengo.go
@@ -89,6 +89,11 @@ func _cgopy_ErrorString(err error) *C.char {
 	return C.CString(err.Error())
 }
 
+//export _cgopy_FreeCString
+func _cgopy_FreeCString(cs *C.char) {
+	C.free(unsafe.Pointer(cs))
+}
+
 // --- end cgo helpers ---
 
 // --- begin cref helpers ---

--- a/main_test.go
+++ b/main_test.go
@@ -667,3 +667,20 @@ doc(pkg):
 `),
 	})
 }
+
+func TestPyErrors(t *testing.T) {
+	t.Parallel()
+	testPkg(t, pkg{
+		path: "_examples/pyerrors",
+		want: []byte(`Divide by zero.
+pyerrors.Div(5, 2) = 2
+`),
+	})
+
+	testPkgWithCFFI(t, pkg{
+		path: "_examples/pyerrors",
+		want: []byte(`Divide by zero.
+pyerrors.Div(5, 2) = 2
+`),
+	})
+}


### PR DESCRIPTION
* Detect functions returning a Go error and make them pythonic (raising an Exception).
* Add tests for it.

Now it only supports 2 return values.
CPy2 and CFFI should support more return values.

Fixes: go-python/gopy#104