### PR TITLE
gopy: go-1.9 requires exactly one main package for c-shared libs

### DIFF
--- a/cmd_bind.go
+++ b/cmd_bind.go
@@ -82,8 +82,7 @@ func gopyRunCmdBind(cmdr *commander.Command, args []string) error {
 	// go-get it to tickle the GOPATH cache (and make sure it compiles
 	// correctly)
 	cmd := exec.Command(
-		"go", "get", "-buildmode=c-shared",
-		pkg.ImportPath(),
+		"go", "get", pkg.ImportPath(),
 	)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
gopy: go-1.9 requires exactly one main package for c-shared libs

Fix: go-python/gopy#108