### PR TITLE
cffi: Support struct types.

### DIFF
--- a/bind/gencffi_cdef.go
+++ b/bind/gencffi_cdef.go
@@ -5,9 +5,16 @@
 package bind
 
 import (
+	"go/types"
 	"strconv"
 	"strings"
 )
+
+func (g *cffiGen) genCdefStruct(s Struct) {
+	g.wrapper.Printf("// A type definition of the %[1]s.%[2]s for wrapping.\n", s.Package().Name(), s.sym.cgoname)
+	g.wrapper.Printf("typedef void* %s;\n", s.sym.cgoname)
+	g.wrapper.Printf("extern void* cgo_func_%s_new();\n", s.sym.id)
+}
 
 func (g *cffiGen) genCdefType(sym *symbol) {
 	if !sym.isType() {
@@ -59,4 +66,66 @@ func (g *cffiGen) genCdefFunc(f Func) {
 	}
 	paramString := strings.Join(params, ", ")
 	g.wrapper.Printf("extern %[1]s cgo_func_%[2]s(%[3]s);\n", cdef_ret, f.id, paramString)
+}
+
+func (g *cffiGen) genCdefMethod(f Func) {
+	var retParams []string
+	var cdef_ret string
+	params := []string{"void* p0"}
+	sig := f.sig
+	rets := sig.Results()
+	args := sig.Params()
+
+	switch len(rets) {
+	case 0:
+		cdef_ret = "void"
+	case 1:
+		cdef_ret = rets[0].sym.cgoname
+	default:
+		for i := 0; i < len(rets); i++ {
+			retParam := rets[i].sym.cgoname + " r" + strconv.Itoa(i)
+			retParams = append(retParams, retParam)
+		}
+		cdef_ret = "cgo_func_" + f.id + "_return"
+		retParamStrings := strings.Join(retParams, "; ")
+		g.wrapper.Printf("typedef struct { %[1]s; } %[2]s;\n", retParamStrings, cdef_ret)
+	}
+
+	for i := 0; i < len(args); i++ {
+		paramVar := args[i].sym.cgoname + " " + "p" + strconv.Itoa(i+1)
+		params = append(params, paramVar)
+	}
+	paramString := strings.Join(params, ", ")
+	g.wrapper.Printf("extern %[1]s cgo_func_%[2]s(%[3]s);\n", cdef_ret, f.id, paramString)
+}
+
+func (g *cffiGen) genCdefStructMemberGetter(s Struct, i int, f types.Object) {
+	pkg := s.Package()
+	ft := f.Type()
+	var (
+		ifield  = newVar(pkg, ft, f.Name(), "ret", "")
+		results = []*Var{ifield}
+	)
+	switch len(results) {
+	case 1:
+		ret := results[0]
+		cdef_ret := ret.sym.cgoname
+		g.wrapper.Printf("extern %[1]s cgo_func_%[2]s_getter_%[3]d(void* p0);\n", cdef_ret, s.sym.id, i+1)
+	default:
+		panic("bind: impossible")
+	}
+}
+
+func (g *cffiGen) genCdefStructMemberSetter(s Struct, i int, f types.Object) {
+	pkg := s.Package()
+	ft := f.Type()
+	var (
+		ifield = newVar(pkg, ft, f.Name(), "ret", "")
+	)
+	cdef_value := ifield.sym.cgoname
+	g.wrapper.Printf("extern void cgo_func_%[1]s_setter_%[2]d(void* p0, %[3]s p1);\n", s.sym.id, i+1, cdef_value)
+}
+
+func (g *cffiGen) genCdefStructTPStr(s Struct) {
+	g.wrapper.Printf("extern GoString cgo_func_%[1]s_str(void* p0);\n", s.sym.id)
 }

--- a/bind/gencffi_func.go
+++ b/bind/gencffi_func.go
@@ -9,6 +9,103 @@ import (
 	"strings"
 )
 
+func (g *cffiGen) genMethod(s Struct, m Func) {
+	sig := m.Signature()
+	args := sig.Params()
+
+	funcArgs := []string{"self"}
+	for _, arg := range args {
+		funcArgs = append(funcArgs, arg.Name())
+	}
+
+	g.wrapper.Printf(`
+#  pythonization of: %[1]s.%[2]s
+def %[2]s(%[3]s):
+    """%[4]s"""
+`,
+		g.pkg.pkg.Name(),
+		m.GoName(),
+		strings.Join(funcArgs, ", "),
+		m.Doc(),
+	)
+	g.wrapper.Indent()
+	g.genMethodBody(s, m)
+	g.wrapper.Outdent()
+	g.wrapper.Printf("\n")
+}
+
+func (g *cffiGen) genMethodBody(s Struct, m Func) {
+	sig := m.Signature()
+	res := sig.Results()
+	args := sig.Params()
+	nres := 0
+
+	funcArgs := []string{"self.cgopy"}
+	for _, arg := range args {
+		if arg.sym.hasConverter() {
+			g.wrapper.Printf("%[1]s = _cffi_helper.cffi_%[2]s(%[3]s)\n", arg.getFuncArg(), arg.sym.py2c, arg.Name())
+			funcArgs = append(funcArgs, arg.getFuncArg())
+		} else {
+			funcArgs = append(funcArgs, arg.Name())
+		}
+	}
+
+	if res != nil {
+		nres = len(res)
+		if nres > 0 {
+			g.wrapper.Printf("cret = ")
+		}
+	}
+	g.wrapper.Printf("_cffi_helper.lib.cgo_func_%[1]s(%[2]s)\n", m.id, strings.Join(funcArgs, ", "))
+
+	if m.err {
+		switch nres {
+		case 1:
+			g.wrapper.Printf("if not _cffi_helper.lib._cgopy_ErrorIsNil(cret):\n")
+			g.wrapper.Indent()
+			g.wrapper.Printf("c_err_str = _cffi_helper.lib._cgopy_ErrorString(cret)\n")
+			g.wrapper.Printf("py_err_str = ffi.string(c_err_str)\n")
+			g.wrapper.Printf("_cffi_helper.lib._cgopy_FreeCString(c_err_str)\n")
+			g.wrapper.Printf("raise RuntimeError(py_err_str)\n")
+			g.wrapper.Outdent()
+			g.wrapper.Printf("return\n")
+			return
+		case 2:
+			g.wrapper.Printf("if not _cffi_helper.lib._cgopy_ErrorIsNil(cret.r1):\n")
+			g.wrapper.Indent()
+			g.wrapper.Printf("c_err_str = _cffi_helper.lib._cgopy_ErrorString(cret.r1)\n")
+			g.wrapper.Printf("py_err_str = ffi.string(c_err_str)\n")
+			g.wrapper.Printf("_cffi_helper.lib._cgopy_FreeCString(c_err_str)\n")
+			g.wrapper.Printf("raise RuntimeError(py_err_str)\n")
+			g.wrapper.Outdent()
+			if res[0].sym.hasConverter() {
+				g.wrapper.Printf("r0 = _cffi_helper.cffi_%[1]s(cret.r0)\n", res[0].sym.c2py)
+				g.wrapper.Printf("return r0\n")
+			} else {
+				g.wrapper.Printf("return cret.r0\n")
+			}
+			return
+		default:
+			panic(fmt.Errorf("bind: function/method with more than 2 results not supported! (%s)", m.ID()))
+		}
+	}
+
+	switch nres {
+	case 0:
+		// no-op
+	case 1:
+		ret := res[0]
+		if ret.sym.hasConverter() {
+			g.wrapper.Printf("ret = _cffi_helper.cffi_%[1]s(cret)\n", ret.sym.c2py)
+			g.wrapper.Printf("return ret\n")
+		} else {
+			g.wrapper.Printf("return cret\n")
+		}
+	default:
+		panic(fmt.Errorf("gopy: Not yet implemeted for multiple return."))
+	}
+}
+
 func (g *cffiGen) genFunc(o Func) {
 	sig := o.Signature()
 	args := sig.Params()

--- a/bind/gencffi_struct.go
+++ b/bind/gencffi_struct.go
@@ -1,0 +1,194 @@
+// Copyright 2017 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bind
+
+import (
+	"fmt"
+	"go/types"
+)
+
+func (g *cffiGen) genStruct(s Struct) {
+	pkgname := s.Package().Name()
+	g.wrapper.Printf(`
+# Python type for struct %[1]s.%[2]s
+class %[2]s(object):
+    """%[3]s"""
+`,
+		pkgname,
+		s.GoName(),
+		s.Doc(),
+	)
+	g.wrapper.Indent()
+	g.genStructInit(s)
+	g.genStructMembers(s)
+	g.genStructMethods(s)
+	g.genStructTPStr(s)
+	g.wrapper.Outdent()
+}
+
+// FIXME: Conversion function should be improved to more memory efficiency way.
+func (g *cffiGen) genStructConversion(s Struct) {
+	g.wrapper.Printf("@staticmethod\n")
+	g.wrapper.Printf("def cffi_cgopy_cnv_py2c_%[1]s_%[2]s(o):\n", s.Package().Name(), s.GoName())
+	g.wrapper.Indent()
+	g.wrapper.Printf("return o.cgopy\n\n")
+	g.wrapper.Outdent()
+
+	g.wrapper.Printf("@staticmethod\n")
+	g.wrapper.Printf("def cffi_cgopy_cnv_c2py_%[1]s_%[2]s(c):\n", s.Package().Name(), s.GoName())
+	g.wrapper.Indent()
+	g.wrapper.Printf("o = %[1]s()\n", s.GoName())
+	g.wrapper.Printf("o.cgopy = ffi.gc(c, _cffi_helper.lib.cgopy_decref)\n")
+	g.wrapper.Printf("return o\n\n")
+	g.wrapper.Outdent()
+}
+
+func (g *cffiGen) genStructInit(s Struct) {
+	pkg := s.Package()
+	pkgname := s.Package().Name()
+	numFields := s.Struct().NumFields()
+	numPublic := numFields
+	for i := 0; i < s.Struct().NumFields(); i++ {
+		f := s.Struct().Field(i)
+		if !f.Exported() {
+			numPublic--
+			continue
+		}
+	}
+
+	g.wrapper.Printf("def __init__(self, *args, **kwargs):\n")
+	g.wrapper.Indent()
+	if numPublic > 0 {
+		g.wrapper.Printf("nkwds = len(kwargs)\n")
+		g.wrapper.Printf("nargs = len(args)\n")
+		g.wrapper.Printf("if nkwds + nargs > %[1]d:\n", numPublic)
+		g.wrapper.Indent()
+		g.wrapper.Printf("raise TypeError('%s.__init__ takes at most %d argument(s)')\n",
+			s.GoName(),
+			numPublic,
+		)
+		g.wrapper.Outdent()
+	}
+	g.wrapper.Printf("cgopy = _cffi_helper.lib.cgo_func_%[1]s_%[2]s_new()\n", pkgname, s.GoName())
+	g.wrapper.Printf("if cgopy == ffi.NULL:\n")
+	g.wrapper.Indent()
+	g.wrapper.Printf("raise MemoryError('gopy: could not allocate %[1]s.')\n", s.GoName())
+	g.wrapper.Outdent()
+	g.wrapper.Printf("self.cgopy = ffi.gc(cgopy, _cffi_helper.lib.cgopy_decref)\n")
+	g.wrapper.Printf("\n")
+
+	for i := 0; i < numFields; i++ {
+		field := s.Struct().Field(i)
+		if !field.Exported() {
+			continue
+		}
+
+		ft := field.Type()
+		var (
+			kwd_name     = fmt.Sprintf("py_kwd_%03d", i+1)
+			cgo_fsetname = fmt.Sprintf("_cffi_helper.lib.cgo_func_%[1]s_setter_%[2]d", s.sym.id, i+1)
+			ifield       = newVar(pkg, ft, field.Name(), "ret", "")
+		)
+
+		g.wrapper.Printf("%[1]s = None\n", kwd_name)
+		g.wrapper.Printf("if  %[1]d < nargs:\n", i)
+		g.wrapper.Indent()
+		g.wrapper.Printf("%[1]s = args[%[2]d]\n", kwd_name, i)
+		g.wrapper.Outdent()
+		g.wrapper.Printf("if %[1]q in kwargs:\n", field.Name())
+		g.wrapper.Indent()
+		g.wrapper.Printf("%[1]s = kwargs[%[2]q]\n", kwd_name, field.Name())
+		g.wrapper.Outdent()
+		g.wrapper.Printf("if %[1]s != None:\n", kwd_name)
+		g.wrapper.Indent()
+		if ifield.sym.hasConverter() {
+			g.wrapper.Printf("c_kwd_%03[1]d = _cffi_helper.cffi_%[2]s(py_kwd_%03[1]d)\n", i+1, ifield.sym.py2c)
+			g.wrapper.Printf("%[1]s(self.cgopy, c_kwd_%03d)\n", cgo_fsetname, i+1)
+		} else {
+			g.wrapper.Printf("%[1]s(self.cgopy, %[2]s)\n", cgo_fsetname, kwd_name)
+		}
+		g.wrapper.Outdent()
+	}
+	g.wrapper.Outdent()
+	g.wrapper.Printf("\n")
+}
+
+func (g *cffiGen) genStructMembers(s Struct) {
+	//pkgname := s.Package().Name()
+	typ := s.Struct()
+	for i := 0; i < typ.NumFields(); i++ {
+		f := typ.Field(i)
+		if !f.Exported() {
+			continue
+		}
+		g.genStructMemberGetter(s, i, f)
+		g.genStructMemberSetter(s, i, f)
+	}
+}
+
+func (g *cffiGen) genStructMemberGetter(s Struct, i int, f types.Object) {
+	pkg := s.Package()
+	ft := f.Type()
+	var (
+		cgo_fgetname = fmt.Sprintf("_cffi_helper.lib.cgo_func_%[1]s_getter_%[2]d", s.sym.id, i+1)
+		ifield       = newVar(pkg, ft, f.Name(), "ret", "")
+		results      = []*Var{ifield}
+	)
+
+	g.wrapper.Printf("@property\n")
+	g.wrapper.Printf("def %[1]s(self):\n", f.Name())
+	g.wrapper.Indent()
+	g.wrapper.Printf("cret =  %[1]s(self.cgopy)\n", cgo_fgetname)
+	switch len(results) {
+	case 1:
+		ret := results[0]
+		if ret.sym.hasConverter() {
+			g.wrapper.Printf("ret = _cffi_helper.cffi_%[1]s(cret)\n", ret.sym.c2py)
+			g.wrapper.Printf("return ret\n")
+		} else {
+			g.wrapper.Printf("return cret\n")
+		}
+	default:
+		panic("bind: impossible")
+	}
+	g.wrapper.Printf("\n")
+	g.wrapper.Outdent()
+}
+
+func (g *cffiGen) genStructMemberSetter(s Struct, i int, f types.Object) {
+	pkg := s.Package()
+	ft := f.Type()
+	var (
+		cgo_fsetname = fmt.Sprintf("_cffi_helper.lib.cgo_func_%[1]s_setter_%[2]d", s.sym.id, i+1)
+		ifield       = newVar(pkg, ft, f.Name(), "ret", "")
+	)
+	g.wrapper.Printf("@%[1]s.setter\n", f.Name())
+	g.wrapper.Printf("def %[1]s(self, value):\n", f.Name())
+	g.wrapper.Indent()
+	if ifield.sym.hasConverter() {
+		g.wrapper.Printf("c_value = _cffi_helper.cffi_%[1]s(value)\n", ifield.sym.py2c)
+		g.wrapper.Printf("%[1]s(self.cgopy, c_value)\n", cgo_fsetname)
+	} else {
+		g.wrapper.Printf("%[1]s(self.cgopy, value)\n", cgo_fsetname)
+	}
+	g.wrapper.Printf("\n")
+	g.wrapper.Outdent()
+}
+
+func (g *cffiGen) genStructMethods(s Struct) {
+	//pkgname := s.Package().Name()
+	for _, m := range s.meths {
+		g.genMethod(s, m)
+	}
+}
+
+func (g *cffiGen) genStructTPStr(s Struct) {
+	g.wrapper.Printf("def __str__(self):\n")
+	g.wrapper.Indent()
+	g.wrapper.Printf("cret = _cffi_helper.lib.cgo_func_%[1]s_str(self.cgopy)\n", s.sym.id)
+	g.wrapper.Printf("ret = _cffi_helper.cffi_cgopy_cnv_c2py_string(cret)\n")
+	g.wrapper.Printf("return ret\n")
+	g.wrapper.Outdent()
+}

--- a/main_test.go
+++ b/main_test.go
@@ -524,6 +524,26 @@ s2.Public = 42
 caught error: 'structs.S2' object has no attribute 'private'
 `),
 	})
+
+	testPkgWithCFFI(t, pkg{
+		path: "_examples/structs",
+		want: []byte(`s = structs.S()
+s = structs.S{}
+s.Init()
+s.Upper('boo')= 'BOO'
+s1 = structs.S1()
+s1 = structs.S1{private:0}
+caught error: 'S1' object has no attribute 'private'
+s2 = structs.S2()
+s2 = structs.S2{Public:0, private:0}
+s2 = structs.S2(1)
+s2 = structs.S2{Public:1, private:0}
+caught error: S2.__init__ takes at most 1 argument(s)
+s2 = structs.S2{Public:42, private:0}
+s2.Public = 42
+caught error: 'S2' object has no attribute 'private'
+`),
+	})
 }
 
 func TestBindConsts(t *testing.T) {


### PR DESCRIPTION
* Generate Struct types from a CFFI engine.
* Passing a Struct type as an argument is supported.
* Passing `structs.go` test.

Update:  go-python/gopy#102
Fix: go-python/gopy#106