### PR TITLE
doc: Fix markdown syntax for license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,5 +184,5 @@ $ docker run -it --rm go-python/gopy
 `gopy` is part of the `go-python` organization and licensed under `BSD-3`.
 When you want to contribute a patch or some code to `gopy`, please send a pull
 request against the `gopy` issue tracker **AND** a pull request against
-(go-python/license)[https://github.com/go-python/license] adding yourself to the
+[go-python/license](https://github.com/go-python/license) adding yourself to the
 `AUTHORS` and `CONTRIBUTORS` files.


### PR DESCRIPTION
Very interested in the interoperability between Python and Go, so I came across this project thanks to the Gophers Slack channel 🙂 

Saw there was a small mistake in formatting a link in the README so figured I'd open this PR.