### PR TITLE
gopy,bind: drop package name out of tp_name

### DIFF
--- a/bind/gencpy_struct.go
+++ b/bind/gencpy_struct.go
@@ -43,7 +43,7 @@ func (g *cpyGen) genStruct(cpy Struct) {
 	g.impl.Indent()
 	g.impl.Printf("PyObject_HEAD_INIT(NULL)\n")
 	g.impl.Printf("0,\t/*ob_size*/\n")
-	g.impl.Printf("\"%s.%s\",\t/*tp_name*/\n", pkgname, cpy.GoName())
+	g.impl.Printf("\"%s\",\t/*tp_name*/\n", cpy.GoName())
 	g.impl.Printf("sizeof(%s),\t/*tp_basicsize*/\n", cpy.sym.cpyname)
 	g.impl.Printf("0,\t/*tp_itemsize*/\n")
 	g.impl.Printf("(destructor)%s_dealloc,\t/*tp_dealloc*/\n", cpy.sym.cpyname)

--- a/main_test.go
+++ b/main_test.go
@@ -711,7 +711,7 @@ s.Init()
 s.Upper('boo')= 'BOO'
 s1 = structs.S1()
 s1 = structs.S1{private:0}
-caught error: 'structs.S1' object has no attribute 'private'
+caught error: 'S1' object has no attribute 'private'
 s2 = structs.S2()
 s2 = structs.S2{Public:0, private:0}
 s2 = structs.S2(1)
@@ -719,7 +719,7 @@ s2 = structs.S2{Public:1, private:0}
 caught error: S2.__init__ takes at most 1 argument(s)
 s2 = structs.S2{Public:42, private:0}
 s2.Public = 42
-caught error: 'structs.S2' object has no attribute 'private'
+caught error: 'S2' object has no attribute 'private'
 `),
 	})
 


### PR DESCRIPTION
Before this CL we used to prepend the Go package name of a struct to the
python name of the corresponding python class:

```python
>>> import pkg
>>> f = pkg.Foo()
>>> f.bar
caught error: 'pkg.Foo' object has no attribute 'bar'
```

This CL drops 'pkg' to make the resulting string follow CPython
convention:

```python
>>> import pkg
>>> f = pkg.Foo()
>>> f.bar
caught error: 'Foo' object has no attribute 'bar'
```

Fixes go-python#gopy/119.