### PR TITLE
gopy: add support for sub-tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -98,35 +98,6 @@ type pkg struct {
 	want []byte
 }
 
-func testPkg(t *testing.T, table pkg) {
-	backends := table.lang
-	if backends == nil {
-		backends = []string{"py2"}
-	}
-	for _, be := range backends {
-		if _, ok := testBackends[be]; !ok {
-			// backend not available.
-			continue
-		}
-		switch be {
-		case "py2":
-			testPkgBackend(t, be, "python2", table)
-		case "py2-cffi":
-			testPkgBackend(t, "cffi", "python2", table)
-		case "py3":
-			testPkgBackend(t, be, "python3", table)
-		case "py3-cffi":
-			testPkgBackend(t, "cffi", "python3", table)
-		case "pypy2-cffi":
-			testPkgBackend(t, "cffi", "pypy", table)
-		case "pypy3-cffi":
-			testPkgBackend(t, "cffi", "pypy3", table)
-		default:
-			t.Errorf("invalid backend name %q", be)
-		}
-	}
-}
-
 func testPkgBackend(t *testing.T, lang, pycmd string, table pkg) {
 	workdir, err := ioutil.TempDir("", "gopy-")
 	if err != nil {

--- a/zsupport_go16_test.go
+++ b/zsupport_go16_test.go
@@ -1,0 +1,38 @@
+// Copyright 2017 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.7
+
+package main
+
+import "testing"
+
+func testPkg(t *testing.T, table pkg) {
+	backends := table.lang
+	if backends == nil {
+		backends = []string{"py2"}
+	}
+	for _, be := range backends {
+		if _, ok := testBackends[be]; !ok {
+			// backend not available.
+			continue
+		}
+		switch be {
+		case "py2":
+			testPkgBackend(t, be, "python2", table)
+		case "py2-cffi":
+			testPkgBackend(t, "cffi", "python2", table)
+		case "py3":
+			testPkgBackend(t, be, "python3", table)
+		case "py3-cffi":
+			testPkgBackend(t, "cffi", "python3", table)
+		case "pypy2-cffi":
+			testPkgBackend(t, "cffi", "pypy", table)
+		case "pypy3-cffi":
+			testPkgBackend(t, "cffi", "pypy3", table)
+		default:
+			t.Errorf("invalid backend name %q", be)
+		}
+	}
+}

--- a/zsupport_test.go
+++ b/zsupport_test.go
@@ -1,0 +1,58 @@
+// Copyright 2017 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.7
+
+package main
+
+import (
+	"testing"
+)
+
+func testPkg(t *testing.T, table pkg) {
+	backends := table.lang
+	if backends == nil {
+		backends = []string{"py2"}
+	}
+	for _, be := range backends {
+		if _, ok := testBackends[be]; !ok {
+			// backend not available.
+			continue
+		}
+		switch be {
+		case "py2":
+			t.Run("py2-python2", func(t *testing.T) {
+				t.Parallel()
+				testPkgBackend(t, "py2", "python2", table)
+			})
+		case "py2-cffi":
+			t.Run(be, func(t *testing.T) {
+				t.Parallel()
+				testPkgBackend(t, "cffi", "python2", table)
+			})
+		case "py3":
+			t.Run(be, func(t *testing.T) {
+				t.Parallel()
+				testPkgBackend(t, be, "python3", table)
+			})
+		case "py3-cffi":
+			t.Run(be, func(t *testing.T) {
+				t.Parallel()
+				testPkgBackend(t, "cffi", "python3", table)
+			})
+		case "pypy2-cffi":
+			t.Run(be, func(t *testing.T) {
+				t.Parallel()
+				testPkgBackend(t, "cffi", "pypy", table)
+			})
+		case "pypy3-cffi":
+			t.Run(be, func(t *testing.T) {
+				t.Parallel()
+				testPkgBackend(t, "cffi", "pypy3", table)
+			})
+		default:
+			t.Errorf("invalid backend name %q", be)
+		}
+	}
+}


### PR DESCRIPTION
This CL adds support for sub-tests for Go >= 1.7 and adds the needed
fallback code for Go < 1.7.

This allows to run sub-tests in parallel, where each sub-test tests a
backend (py2-cffi, py3-cffi, py3, ...).