### PR TITLE
test: Running go test without py2-cffi throws errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,18 @@ matrix:
 sudo: required
 
 before_install:
-   - sudo apt-get install libffi-dev python-cffi
-   - export PATH=$HOME/gopath/bin:$PATH
+   - sudo apt-get install libffi-dev python-cffi pypy python3-cffi
+   - export PATH=$HOME/gopath/bin:/usr/local/bin:$PATH
+   # Init() in main_test will make sure all backends are available if
+   # GOPY_TRAVIS_CI is set
+   - export GOPY_TRAVIS_CI=1
    # temporary workaround for go-python/gopy#83
    - export GODEBUG=cgocheck=0
+   # pypy3 isn't packaged in ubuntu yet.
+   - TEMPDIR=$(mktemp -d)
+   - curl -L https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.10.0-linux_x86_64-portable.tar.bz2 --output $TEMPDIR/pypy3.tar.bz2
+   - tar xf $TEMPDIR/pypy3.tar.bz2 -C $TEMPDIR
+   - sudo ln -s $TEMPDIR/pypy3.5-5.10.0-linux_x86_64-portable/bin/pypy3 /usr/local/bin/pypy3
 
 notifications:
   email:

--- a/zsupport_test.go
+++ b/zsupport_test.go
@@ -16,8 +16,9 @@ func testPkg(t *testing.T, table pkg) {
 		backends = []string{"py2"}
 	}
 	for _, be := range backends {
-		if _, ok := testBackends[be]; !ok {
+		if !testBackends[be] {
 			// backend not available.
+			t.Logf("Skipped testing backend %s for %s\n", be, table.path)
 			continue
 		}
 		switch be {


### PR DESCRIPTION
- There was a bug in test which didn't disable py2-cffi test backend
  even if the cffi module wasn't present on the system. This was because py2
  and py2-cffi were by default part of the enabled backends and were never disabled.
- We shouldn't have default enabled backends and should enable
  only if support is present.
- The value for testBackends needs to be only a bool instead of an int.
- Also added some log messages.