### PR TITLE
gopy,bind: sanitize symbol ids

### DIFF
--- a/_issues/issue148/pkg.go
+++ b/_issues/issue148/pkg.go
@@ -1,0 +1,11 @@
+// Copyright 2018 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package issue148
+
+import "encoding/json"
+
+type T struct {
+	Msg json.RawMessage
+}

--- a/_issues/issue148/test.py
+++ b/_issues/issue148/test.py
@@ -1,0 +1,8 @@
+# Copyright 2018 The go-python Authors.  All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from __future__ import print_function
+import issue148
+
+print("OK\n")

--- a/bind/package.go
+++ b/bind/package.go
@@ -468,9 +468,10 @@ func newFuncFrom(p *Package, parent string, obj types.Object, sig *types.Signatu
 		return Func{}, fmt.Errorf("bind: too many results to return: %v", obj)
 	}
 
-	id := obj.Pkg().Name() + "_" + obj.Name()
+	pkgname := sanitize(obj.Pkg().Name())
+	id := pkgname + "_" + obj.Name()
 	if parent != "" {
-		id = obj.Pkg().Name() + "_" + parent + "_" + obj.Name()
+		id = pkgname + "_" + sanitize(parent) + "_" + obj.Name()
 	}
 
 	return Func{

--- a/bind/symtab.go
+++ b/bind/symtab.go
@@ -292,6 +292,7 @@ func (sym *symtab) addSymbol(obj types.Object) {
 	if pkg != nil {
 		id = pkg.Name() + "_" + n
 	}
+	id = sanitize(id)
 	switch obj.(type) {
 	case *types.Const:
 		sym.syms[fn] = &symbol{
@@ -364,6 +365,7 @@ func (sym *symtab) addType(obj types.Object, t types.Type) {
 	if pkg != nil {
 		id = pkg.Name() + "_" + n
 	}
+	id = sanitize(id)
 	kind := skType
 	switch typ := t.(type) {
 	case *types.Basic:

--- a/bind/utils.go
+++ b/bind/utils.go
@@ -158,3 +158,9 @@ func getGoVersion(version string) (int64, int64, error) {
 	minor, _ := strconv.ParseInt(version_info[1], 10, 0)
 	return major, minor, nil
 }
+
+func sanitize(s string) string {
+	s = strings.Replace(s, ".", "_", -1)
+	s = strings.Replace(s, "/", "_", -1)
+	return s
+}

--- a/main_test.go
+++ b/main_test.go
@@ -778,3 +778,36 @@ GetString() = MyString
 `),
 	})
 }
+
+func TestIssues(t *testing.T) {
+	dirs, err := filepath.Glob("_issues/*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dirs) == 0 {
+		t.Fatalf("cannot find _issues")
+	}
+	exclude := []string{ // TODO(sbinet): remove this list
+		"issue148",
+	}
+	for _, dir := range dirs {
+		skip := false
+		name := filepath.Base(dir)
+		for _, n := range exclude {
+			if n == name {
+				skip = true
+			}
+		}
+		if skip {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			testPkg(t, pkg{
+				path: dir,
+				lang: []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
+				want: []byte("OK"),
+			})
+		})
+	}
+}


### PR DESCRIPTION
This CL makes sure there are no '/' nor '.' in symbol ids.
Such characters could come from a package path (e.g.: "encoding/json")
or from a fully qualified type name (e.g. json.RawMessage)

Updates go-python/gopy#148.