### PR TITLE
cffi: Fix invalid syntax for slices in generated Python

### DIFF
--- a/_examples/lot/lot.go
+++ b/_examples/lot/lot.go
@@ -1,0 +1,32 @@
+// Copyright 2018 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Reference from: https://github.com/initialed85/golang_python_binding_research
+
+package lot
+
+type Value struct {
+	SomeString        string
+	SomeInt           int64
+	SomeFloat         float64
+	SomeBool          bool
+	SomeListOfStrings []string
+	SomeListOfInts    []int64
+	SomeListOfFloats  []float64
+	SomeListOfBools   []bool
+}
+
+// New returns a struct with exported fields of different types
+func New() Value {
+	return Value{
+		"some string",
+		1337,
+		1337.1337,
+		true,
+		[]string{"some", "list", "of", "strings"},
+		[]int64{6, 2, 9, 1},
+		[]float64{6.6, 2.2, 9.9, 1.1},
+		[]bool{true, false, true, false},
+	}
+}

--- a/_examples/lot/test.py
+++ b/_examples/lot/test.py
@@ -1,0 +1,14 @@
+# Copyright 2018 The go-python Authors.  All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+import lot
+
+l = lot.New()
+print('l.SomeString : {}'.format(l.SomeString))
+print('l.SomeInt : {}'.format(l.SomeInt))
+print('l.SomeFloat : {}'.format(l.SomeFloat))
+print('l.SomeBool : {}'.format(l.SomeBool))
+print('l.SomeListOfStrings: {}'.format(l.SomeListOfStrings))
+print('l.SomeListOfInts: {}'.format(l.SomeListOfInts))
+print('l.SomeListOfFloats: {}'.format(l.SomeListOfFloats))
+print('l.SomeListOfBools: {}'.format(l.SomeListOfBools))

--- a/bind/gencffi_struct.go
+++ b/bind/gencffi_struct.go
@@ -104,7 +104,11 @@ func (g *cffiGen) genStructInit(s Struct) {
 		g.wrapper.Outdent()
 		g.wrapper.Printf("if %[1]s != None:\n", kwd_name)
 		g.wrapper.Indent()
-		g.wrapper.Printf("if not isinstance(%[1]s, %[2]s):\n", kwd_name, ifield.sym.pysig)
+		if ifield.sym.isSlice() {
+			g.wrapper.Printf("if not isinstance(%[1]s, list):\n", kwd_name)
+		} else {
+			g.wrapper.Printf("if not isinstance(%[1]s, %[2]s):\n", kwd_name, ifield.sym.pysig)
+		}
 		g.wrapper.Indent()
 		g.wrapper.Printf("raise TypeError(\"invalid type for '%[1]s' attribute\")\n", field.Name())
 		g.wrapper.Outdent()

--- a/main_test.go
+++ b/main_test.go
@@ -791,3 +791,21 @@ GetString() = MyString
 `),
 	})
 }
+
+func TestLot(t *testing.T) {
+	t.Parallel()
+	path := "_examples/lot"
+	testPkg(t, pkg{
+		path: path,
+		lang: []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
+		want: []byte(`l.SomeString : some string
+l.SomeInt : 1337
+l.SomeFloat : 1337.1337
+l.SomeBool : True
+l.SomeListOfStrings: []string{"some", "list", "of", "strings"}
+l.SomeListOfInts: []int64{6, 2, 9, 1}
+l.SomeListOfFloats: []float64{6.6, 2.2, 9.9, 1.1}
+l.SomeListOfBools: []bool{true, false, true, false}
+`),
+	})
+}


### PR DESCRIPTION
This CL makes valid syntax for slices cases.

Updates go-python/gopy#156.