### PR TITLE
Add the ability to change method and function names

### DIFF
--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -17,6 +17,7 @@ _examples/maps | no | yes | yes | yes | yes
 _examples/named | yes | yes | yes | yes | yes
 _examples/pointers | no | no | no | no | no
 _examples/pyerrors | yes | yes | yes | yes | yes
+_examples/rename | yes | yes | yes | yes | yes
 _examples/seqs | yes | yes | yes | yes | yes
 _examples/simple | yes | yes | yes | yes | yes
 _examples/slices | no | yes | yes | yes | yes

--- a/_examples/rename/rename.go
+++ b/_examples/rename/rename.go
@@ -1,0 +1,19 @@
+// Copyright 2018 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// package rename tests changing the names of methods and functions
+package rename
+
+//gopy:name say_hi
+func SayHi() string {
+	return "hi"
+}
+
+type MyStruct struct {
+}
+
+//gopy:name say_something
+func (s *MyStruct) SaySomething() (something string) {
+	return "something"
+}

--- a/_examples/rename/test.py
+++ b/_examples/rename/test.py
@@ -1,0 +1,11 @@
+# Copyright 2018 The go-python Authors.  All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+## py2/py3 compat
+from __future__ import print_function
+
+import rename
+
+print(rename.say_hi())
+print(rename.MyStruct().say_something())

--- a/bind/gencffi_func.go
+++ b/bind/gencffi_func.go
@@ -18,6 +18,10 @@ func (g *cffiGen) genMethod(s Struct, m Func) {
 	for _, arg := range args {
 		funcArgs = append(funcArgs, arg.Name())
 	}
+	gname, gdoc, err := extractPythonName(m.GoName(), m.Doc())
+	if err != nil {
+		panic(err)
+	}
 
 	g.wrapper.Printf(`
 #  pythonization of: %[1]s.%[2]s
@@ -25,9 +29,9 @@ def %[2]s(%[3]s):
     ""%[4]q""
 `,
 		g.pkg.pkg.Name(),
-		m.GoName(),
+		gname,
 		strings.Join(funcArgs, ", "),
-		m.Doc(),
+		gdoc,
 	)
 	g.wrapper.Indent()
 	g.genMethodBody(s, m)
@@ -111,15 +115,19 @@ func (g *cffiGen) genFunc(o Func) {
 	for _, arg := range args {
 		funcArgs = append(funcArgs, arg.Name())
 	}
+	gname, gdoc, err := extractPythonName(o.GoName(), o.Doc())
+	if err != nil {
+		panic(err)
+	}
 	g.wrapper.Printf(`
 # pythonization of: %[1]s.%[2]s 
 def %[2]s(%[3]s):
     ""%[4]q""
 `,
 		g.pkg.pkg.Name(),
-		o.GoName(),
+		gname,
 		strings.Join(funcArgs, ", "),
-		o.Doc(),
+		gdoc,
 	)
 
 	g.wrapper.Indent()

--- a/bind/gencpy.go
+++ b/bind/gencpy.go
@@ -215,10 +215,13 @@ func (g *cpyGen) gen() error {
 	g.impl.Printf("static PyMethodDef cpy_%s_methods[] = {\n", g.pkg.pkg.Name())
 	g.impl.Indent()
 	for _, f := range g.pkg.funcs {
-		name := f.GoName()
 		//obj := scope.Lookup(name)
+		gname, gdoc, err := extractPythonName(f.GoName(), f.Doc())
+		if err != nil {
+			panic(err)
+		}
 		g.impl.Printf("{%[1]q, %[2]s, METH_VARARGS, %[3]q},\n",
-			name, "cpy_func_"+f.ID(), f.Doc(),
+			gname, "cpy_func_"+f.ID(), gdoc,
 		)
 	}
 	// expose ctors at module level

--- a/bind/gencpy_struct.go
+++ b/bind/gencpy_struct.go
@@ -430,12 +430,16 @@ func (g *cpyGen) genStructMethods(cpy Struct) {
 		if len(m.Signature().Params()) == 0 {
 			margs = "METH_NOARGS"
 		}
+		gname, gdoc, err := extractPythonName(m.GoName(), m.Doc())
+		if err != nil {
+			panic(err)
+		}
 		g.impl.Printf(
 			"{%[1]q, (PyCFunction)cpy_func_%[2]s, %[3]s, %[4]q},\n",
-			m.GoName(),
+			gname,
 			m.ID(),
 			margs,
-			m.Doc(),
+			gdoc,
 		)
 	}
 	g.impl.Printf("{NULL} /* sentinel */\n")

--- a/bind/utils.go
+++ b/bind/utils.go
@@ -158,3 +158,20 @@ func getGoVersion(version string) (int64, int64, error) {
 	minor, _ := strconv.ParseInt(version_info[1], 10, 0)
 	return major, minor, nil
 }
+
+func extractPythonName(gname, gdoc string) (string, string, error) {
+	const PythonName = "\ngopy:name "
+	i := strings.Index(gdoc, PythonName)
+	if i < 0 {
+		return gname, gdoc, nil
+	}
+	s := gdoc[i+len(PythonName):]
+	if end := strings.Index(s, "\n"); end > 0 {
+		validIdPattern := regexp.MustCompile(`^[\pL][\pL_\pN]+$`)
+		if !validIdPattern.MatchString(s[:end]) {
+			return "", "", fmt.Errorf("gopy: invalid identifier: %s", s[:end])
+		}
+		return s[:end], gdoc[:i] + s[end:], nil
+	}
+	return gname, gdoc, nil
+}

--- a/bind/utils_test.go
+++ b/bind/utils_test.go
@@ -38,3 +38,33 @@ func TestGetGoVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestExtractPythonName(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		goDoc    string
+		newName  string
+		newGoDoc string
+		err      error
+	}{
+		{"Func1", "", "Func1", "", nil},
+		{"Func2", "\ngopy:name func2\n", "func2", "\n", nil},
+		{"Func3", "\ngopy:name bad name\n", "", "", errors.New("gopy: invalid identifier: bad name")},
+		{"Func4", "\nsome comment\n", "Func4", "\nsome comment\n", nil},
+		{"Func5", "\nsome comment\ngopy:name func5\n", "func5", "\nsome comment\n", nil},
+	} {
+		newName, newGoDoc, err := extractPythonName(tt.name, tt.goDoc)
+
+		if newName != tt.newName {
+			t.Errorf("extractPythonName(%s, %s): expected name %s, actual %s", tt.name, tt.goDoc, tt.newName, newName)
+		}
+
+		if newGoDoc != tt.newGoDoc {
+			t.Errorf("extractPythonName(%s, %s): expected comment %s, actual %s", tt.name, tt.goDoc, tt.newGoDoc, newGoDoc)
+		}
+
+		if err != nil && err.Error() != tt.err.Error() {
+			t.Errorf("extractPythonName(%s, %s): expected err %s, actual %s", tt.name, tt.goDoc, tt.err, err)
+		}
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -211,6 +211,7 @@ var features = map[string][]string{
 	"_examples/slices":    []string{"py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 	"_examples/maps":      []string{"py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 	"_examples/gostrings": []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
+	"_examples/rename":    []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 }
 
 func TestHi(t *testing.T) {
@@ -826,6 +827,18 @@ func TestBindStrings(t *testing.T) {
 		lang: features[path],
 		want: []byte(`S1 = S1
 GetString() = MyString
+`),
+	})
+}
+
+func TestBindRename(t *testing.T) {
+	t.Parallel()
+	path := "_examples/rename"
+	testPkg(t, pkg{
+		path: path,
+		lang: features[path],
+		want: []byte(`hi
+something
 `),
 	})
 }


### PR DESCRIPTION
We're porting a library to Go using Gopy and we need to keep the method and function names the same as in the old implementation.

Currently, only exported functions, starting with an uppercase character, can have a binding generated.

This PR adds a directive, which allows changing the name in the following way:

```
//python:name test
func Test() {
   ...
}
```
