### PR TITLE
Support for pointer-to-slice parameters

### DIFF
--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -19,6 +19,7 @@ _examples/pointers | no | no | no | no | no
 _examples/pyerrors | yes | yes | yes | yes | yes
 _examples/seqs | yes | yes | yes | yes | yes
 _examples/simple | yes | yes | yes | yes | yes
+_examples/sliceptr | yes | no | no | no | no
 _examples/slices | no | yes | yes | yes | yes
 _examples/structs | yes | yes | yes | yes | yes
 _examples/vars | yes | yes | yes | yes | yes

--- a/_examples/sliceptr/sliceptr.go
+++ b/_examples/sliceptr/sliceptr.go
@@ -1,0 +1,34 @@
+// Copyright 2018 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// package sliceptr tests support for pointer-to-slice arguments
+// useful for getting bulk data from Go to Python
+
+package sliceptr
+
+import "strconv"
+
+type StrVector []string
+type IntVector []int
+
+func Fill(iv *IntVector) {
+	*iv = IntVector{1, 2, 3}
+}
+
+func Append(iv *IntVector) {
+	*iv = append(*iv, 4)
+}
+
+func Convert(iv *IntVector, sv *StrVector) {
+	for _, v := range *iv {
+		*sv = append(*sv, strconv.Itoa(v))
+	}
+}
+
+// compiles, but dies with SIGSEGV
+//func (iv *IntVector) Convert(sv *StrVector) {
+//	for _, v := range *iv {
+//		*sv = append(*sv, strconv.Itoa(v))
+//	}
+//}

--- a/_examples/sliceptr/test.py
+++ b/_examples/sliceptr/test.py
@@ -1,0 +1,18 @@
+# Copyright 2018 The go-python Authors.  All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+## py2/py3 compat
+from __future__ import print_function
+
+import sliceptr
+
+i = sliceptr.IntVector()
+
+sliceptr.Fill(i)
+print(i)
+sliceptr.Append(i)
+print(i)
+s = sliceptr.StrVector()
+sliceptr.Convert(i, s)
+print(s)

--- a/bind/gencpy_type.go
+++ b/bind/gencpy_type.go
@@ -20,6 +20,9 @@ func (g *cpyGen) genType(sym *symbol) {
 	if sym.isBasic() && !sym.isNamed() {
 		return
 	}
+	if sym.isPointer() {
+		return
+	}
 
 	g.decl.Printf("\n/* --- decls for type %v --- */\n", sym.gofmt())
 	if sym.isBasic() {

--- a/bind/symtab.go
+++ b/bind/symtab.go
@@ -144,6 +144,10 @@ func (s symbol) isStruct() bool {
 	return (s.kind & skStruct) != 0
 }
 
+func (s symbol) isPointer() bool {
+	return (s.kind & skPointer) != 0
+}
+
 func (s symbol) hasConverter() bool {
 	return s.pyfmt == "O&" && (s.c2py != "" || s.py2c != "")
 }
@@ -361,6 +365,9 @@ func (sym *symtab) addType(obj types.Object, t types.Type) {
 	var pkg *types.Package
 	if obj != nil {
 		pkg = obj.Pkg()
+	}
+	if pkg == nil {
+		pkg = sym.pkg
 	}
 	id := n
 	if pkg != nil {

--- a/bind/vars.go
+++ b/bind/vars.go
@@ -52,7 +52,7 @@ func getTypeString(t types.Type) string {
 }
 
 func (v *Var) GoType() types.Type {
-	return v.sym.goobj.Type()
+	return v.sym.gotyp
 }
 
 func (v *Var) CType() string {

--- a/main_test.go
+++ b/main_test.go
@@ -196,6 +196,7 @@ var features = map[string][]string{
 	// are fixed.
 	"_examples/hi":        []string{"py2"},
 	"_examples/funcs":     []string{"py2"},
+	"_examples/sliceptr":  []string{"py2"},
 	"_examples/simple":    []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 	"_examples/empty":     []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 	"_examples/named":     []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
@@ -844,6 +845,19 @@ l.SomeListOfStrings: []string{"some", "list", "of", "strings"}
 l.SomeListOfInts: []int64{6, 2, 9, 1}
 l.SomeListOfFloats: []float64{6.6, 2.2, 9.9, 1.1}
 l.SomeListOfBools: []bool{true, false, true, false}
+`),
+	})
+}
+
+func TestSlicePtr(t *testing.T) {
+	t.Parallel()
+	path := "_examples/sliceptr"
+	testPkg(t, pkg{
+		path: path,
+		lang: []string{"py2"}, //, "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
+		want: []byte(`sliceptr.IntVector{1, 2, 3}
+sliceptr.IntVector{1, 2, 3, 4}
+sliceptr.StrVector{"1", "2", "3", "4"}
 `),
 	})
 }


### PR DESCRIPTION
Implement support for pointer-to-slice parameters for methods and functions:

Python:
```
import tst
s = tst.StrSlice()
tst.Fill(s)
print s
```

Go:
```
package tst
type StrSlice []string
func Fill(s *StrSlice) {
        *s = StrSlice{"A", "B"}
}
```

This doesn't implement pointer support in general (as we didn't need it), but the fixes should make the implementation easier.