### PR TITLE
gopy/bind: allow renamed Python identifiers to start with an underscore

### DIFF
--- a/bind/utils.go
+++ b/bind/utils.go
@@ -167,7 +167,7 @@ func extractPythonName(gname, gdoc string) (string, string, error) {
 	}
 	s := gdoc[i+len(PythonName):]
 	if end := strings.Index(s, "\n"); end > 0 {
-		validIdPattern := regexp.MustCompile(`^[\pL][\pL_\pN]+$`)
+		validIdPattern := regexp.MustCompile(`^[\pL_][\pL_\pN]+$`)
 		if !validIdPattern.MatchString(s[:end]) {
 			return "", "", fmt.Errorf("gopy: invalid identifier: %s", s[:end])
 		}

--- a/bind/utils_test.go
+++ b/bind/utils_test.go
@@ -52,6 +52,7 @@ func TestExtractPythonName(t *testing.T) {
 		{"Func3", "\ngopy:name bad name\n", "", "", errors.New("gopy: invalid identifier: bad name")},
 		{"Func4", "\nsome comment\n", "Func4", "\nsome comment\n", nil},
 		{"Func5", "\nsome comment\ngopy:name func5\n", "func5", "\nsome comment\n", nil},
+		{"Func6", "\nsome comment\ngopy:name __len__\n", "__len__", "\nsome comment\n", nil},
 	} {
 		newName, newGoDoc, err := extractPythonName(tt.name, tt.goDoc)
 


### PR DESCRIPTION
Sorry, I messed up the identifier validation. Underscores should be allowed at any position.