### PR TITLE
gopy/bind: support pointers-to-slices with the cffi backend

### DIFF
--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -20,7 +20,7 @@ _examples/pyerrors | yes | yes | yes | yes | yes
 _examples/rename | yes | yes | yes | yes | yes
 _examples/seqs | yes | yes | yes | yes | yes
 _examples/simple | yes | yes | yes | yes | yes
-_examples/sliceptr | yes | no | no | no | no
+_examples/sliceptr | yes | yes | yes | yes | yes
 _examples/slices | no | yes | yes | yes | yes
 _examples/structs | yes | yes | yes | yes | yes
 _examples/vars | yes | yes | yes | yes | yes

--- a/bind/gencffi.go
+++ b/bind/gencffi.go
@@ -249,6 +249,9 @@ func (g *cffiGen) genWrappedPy() {
 		if !sym.isType() {
 			continue
 		}
+		if sym.isPointer() {
+			continue
+		}
 		g.genTypeConverter(sym)
 	}
 

--- a/bind/gencffi_cdef.go
+++ b/bind/gencffi_cdef.go
@@ -33,6 +33,10 @@ func (g *cffiGen) genCdefType(sym *symbol) {
 		return
 	}
 
+	if sym.isPointer() {
+		return
+	}
+
 	g.genTypeCdefInit(sym)
 
 	if sym.isNamed() {

--- a/bind/gencffi_type.go
+++ b/bind/gencffi_type.go
@@ -20,6 +20,9 @@ func (g *cffiGen) genType(sym *symbol) {
 	if sym.isBasic() && !sym.isNamed() {
 		return
 	}
+	if sym.isPointer() {
+		return
+	}
 
 	var typename string
 
@@ -325,6 +328,10 @@ func (g *cffiGen) genTypeConverter(sym *symbol) {
 
 // genTypeMethod generates Type methods.
 func (g *cffiGen) genTypeMethod(sym *symbol) {
+	if sym.isPointer() {
+		return
+	}
+
 	g.wrapper.Printf("# methods for %s\n", sym.gofmt())
 	if sym.isNamed() {
 		typ := sym.GoType().(*types.Named)

--- a/main_test.go
+++ b/main_test.go
@@ -196,7 +196,7 @@ var features = map[string][]string{
 	// are fixed.
 	"_examples/hi":        []string{"py2"},
 	"_examples/funcs":     []string{"py2"},
-	"_examples/sliceptr":  []string{"py2"},
+	"_examples/sliceptr":  []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 	"_examples/simple":    []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 	"_examples/empty":     []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 	"_examples/named":     []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
@@ -867,7 +867,7 @@ func TestSlicePtr(t *testing.T) {
 	path := "_examples/sliceptr"
 	testPkg(t, pkg{
 		path: path,
-		lang: []string{"py2"}, //, "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
+		lang: []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 		want: []byte(`sliceptr.IntVector{1, 2, 3}
 sliceptr.IntVector{1, 2, 3, 4}
 sliceptr.StrVector{"1", "2", "3", "4"}


### PR DESCRIPTION
This PR makes the `sliceptr` example work with the CFFI backend.

Improves https://github.com/go-python/gopy/commit/5f71fa457cb119a5e2ddf38ee7c1f4a963f2b178 .