### PR TITLE
gopy/bind: encode strings passed to Go using the CFFI backend as UTF-8

### DIFF
--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -23,4 +23,5 @@ _examples/simple | yes | yes | yes | yes | yes
 _examples/sliceptr | yes | yes | yes | yes | yes
 _examples/slices | no | yes | yes | yes | yes
 _examples/structs | yes | yes | yes | yes | yes
+_examples/unicode | yes | yes | yes | yes | yes
 _examples/vars | yes | yes | yes | yes | yes

--- a/_examples/unicode/encoding.go
+++ b/_examples/unicode/encoding.go
@@ -1,0 +1,15 @@
+// Copyright 2018 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package encoding
+
+var gostring = "Go Unicode string 🐱"
+
+func HandleString(s string) string {
+	return s
+}
+
+func GetString() string {
+	return gostring
+}

--- a/_examples/unicode/test.py
+++ b/_examples/unicode/test.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 The go-python Authors.  All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+## py2/py3 compat
+from __future__ import print_function, unicode_literals
+
+import encoding
+
+bytestr = b"Python byte string"
+unicodestr = u"Python Unicode string 🐱"
+
+bytestr_ret = encoding.HandleString(bytestr)
+unicodestr_ret = encoding.HandleString(unicodestr)
+
+print("encoding.HandleString(bytestr) ->", bytestr_ret)
+print("encoding.HandleString(unicodestr) ->", unicodestr_ret)
+
+gostring_ret = encoding.GetString()
+print("encoding.GetString() ->", gostring_ret)
+

--- a/bind/gencffi.go
+++ b/bind/gencffi.go
@@ -87,8 +87,8 @@ class _cffi_helper(object):
 
     @staticmethod
     def cffi_cgopy_cnv_py2c_string(o):
-        if _PY3:
-            o = o.encode('ascii')
+        if (_PY3 and isinstance(o, str)) or (not _PY3 and isinstance(o, unicode)):
+            o = o.encode('utf8')
         s = ffi.new("char[]", o)
         return _cffi_helper.lib._cgopy_GoString(s)
 

--- a/bind/gencpy.go
+++ b/bind/gencpy.go
@@ -103,11 +103,25 @@ cgopy_cnv_c2py_bool(GoUint8 *addr) {
 
 static int
 cgopy_cnv_py2c_string(PyObject *o, GoString *addr) {
-	const char *str = PyString_AsString(o);
-	if (str == NULL) {
-		return 0;
+	if (PyUnicode_Check(o)) {
+		o = PyUnicode_AsUTF8String(o);
+		if (o == NULL) {
+			return 0;
+		}
+		const char *str = PyString_AsString(o);
+		if (str == NULL) {
+			Py_DECREF(o);
+			return 0;
+		}
+		*addr = _cgopy_GoString((char*)str);
+		Py_DECREF(o);
+	} else {
+		const char *str = PyString_AsString(o);
+		if (str == NULL) {
+			return 0;
+		}
+		*addr = _cgopy_GoString((char*)str);
 	}
-	*addr = _cgopy_GoString((char*)str);
 	return 1;
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -213,6 +213,7 @@ var features = map[string][]string{
 	"_examples/maps":      []string{"py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 	"_examples/gostrings": []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 	"_examples/rename":    []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
+	"_examples/unicode":   []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 }
 
 func TestHi(t *testing.T) {
@@ -873,6 +874,19 @@ func TestSlicePtr(t *testing.T) {
 		want: []byte(`sliceptr.IntVector{1, 2, 3}
 sliceptr.IntVector{1, 2, 3, 4}
 sliceptr.StrVector{"1", "2", "3", "4"}
+`),
+	})
+}
+
+func TestUnicode(t *testing.T) {
+	t.Parallel()
+	path := "_examples/unicode"
+	testPkg(t, pkg{
+		path: path,
+		lang: []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
+		want: []byte(`encoding.HandleString(bytestr) -> Python byte string
+encoding.HandleString(unicodestr) -> Python Unicode string 🐱
+encoding.GetString() -> Go Unicode string 🐱
 `),
 	})
 }


### PR DESCRIPTION
Strings passed the other way are already UTF-8 encoded, this makes everything symmetric and working in many more cases.