### PR TITLE
Pass Go strings to Python as Unicode objects

### DIFF
--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -23,4 +23,5 @@ _examples/simple | yes | yes | yes | yes | yes
 _examples/sliceptr | yes | yes | yes | yes | yes
 _examples/slices | no | yes | yes | yes | yes
 _examples/structs | yes | yes | yes | yes | yes
+_examples/unicode | yes | yes | yes | yes | yes
 _examples/vars | yes | yes | yes | yes | yes

--- a/_examples/cgo/test.py
+++ b/_examples/cgo/test.py
@@ -7,6 +7,6 @@ from __future__ import print_function
 
 import cgo
 
-print("cgo.doc: %r" % (cgo.__doc__,))
-print("cgo.Hi()= %r" % (cgo.Hi(),))
-print("cgo.Hello(you)= %r" % (cgo.Hello("you"),))
+print("cgo.doc: %s" % repr(cgo.__doc__).lstrip('u'))
+print("cgo.Hi()= %s" % repr(cgo.Hi()).lstrip('u'))
+print("cgo.Hello(you)= %s" % repr(cgo.Hello("you")).lstrip('u'))

--- a/_examples/empty/test.py
+++ b/_examples/empty/test.py
@@ -7,5 +7,5 @@ from __future__ import print_function
 
 import empty as pkg
 
-print("doc(pkg):\n%s" % repr(pkg.__doc__))
+print("doc(pkg):\n%s" % repr(pkg.__doc__).lstrip('u'))
 

--- a/_examples/named/test.py
+++ b/_examples/named/test.py
@@ -14,9 +14,9 @@ if _PY3:
 import named
 
 ### test docs
-print("doc(named): %r" % (named.__doc__,))
-print("doc(named.Float): %r" % (named.Float.__doc__,))
-print("doc(named.Float.Value): %r" % (named.Float.Value.__doc__,))
+print("doc(named): %s" % repr(named.__doc__).lstrip('u'))
+print("doc(named.Float): %s" % repr(named.Float.__doc__).lstrip('u'))
+print("doc(named.Float.Value): %s" % repr(named.Float.Value.__doc__).lstrip('u'))
 
 print("v = named.Float()")
 v = named.Float()
@@ -83,12 +83,12 @@ print("x.Value() = %s" % (x.Value(),))
 print("s = named.Str()")
 s = named.Str()
 print("s = %s" % (s,))
-print("s.Value() = %r" % (s.Value(),))
+print("s.Value() = %s" % repr(s.Value()).lstrip('u'))
 
 print("s = named.Str('string')")
 s = named.Str("string")
 print("s = %s" % (s,))
-print("s.Value() = %r" % (s.Value(),))
+print("s.Value() = %s" % repr(s.Value()).lstrip('u'))
 
 print("arr = named.Array()")
 arr = named.Array()

--- a/_examples/seqs/test.py
+++ b/_examples/seqs/test.py
@@ -13,7 +13,7 @@ if _PY3:
 import seqs
 
 ### test docs
-print("doc(seqs): %r" % (seqs.__doc__,))
+print("doc(seqs): %s" % repr(seqs.__doc__).lstrip('u'))
 
 print("arr = seqs.Array(xrange(2))")
 arr = seqs.Array(xrange(2))

--- a/_examples/simple/test.py
+++ b/_examples/simple/test.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 
 import simple as pkg
 
-print("doc(pkg):\n%s" % repr(pkg.__doc__))
+print("doc(pkg):\n%s" % repr(pkg.__doc__).lstrip('u'))
 print("pkg.Func()...")
 pkg.Func()
 print("fct = pkg.Func...")

--- a/_examples/structs/test.py
+++ b/_examples/structs/test.py
@@ -12,7 +12,7 @@ s = structs.S()
 print("s = %s" % (s,))
 print("s.Init()")
 s.Init()
-print("s.Upper('boo')= %r" % (s.Upper("boo"),))
+print("s.Upper('boo')= %s" % repr(s.Upper("boo")).lstrip('u'))
 
 print("s1 = structs.S1()")
 s1 = structs.S1()

--- a/_examples/unicode/encoding.go
+++ b/_examples/unicode/encoding.go
@@ -1,0 +1,15 @@
+// Copyright 2018 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package encoding
+
+var gostring = "Go Unicode string 🐱"
+
+func HandleString(s string) string {
+	return s
+}
+
+func GetString() string {
+	return gostring
+}

--- a/_examples/unicode/test.py
+++ b/_examples/unicode/test.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 The go-python Authors.  All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+## py2/py3 compat
+from __future__ import print_function, unicode_literals
+
+import encoding
+
+bytestr = b"Python byte string"
+unicodestr = u"Python Unicode string 🐱"
+
+bytestr_ret = encoding.HandleString(bytestr)
+unicodestr_ret = encoding.HandleString(unicodestr)
+
+print("encoding.HandleString(bytestr) ->", bytestr_ret)
+print("encoding.HandleString(unicodestr) ->", unicodestr_ret)
+
+gostring_ret = encoding.GetString()
+print("encoding.GetString() ->", gostring_ret)
+

--- a/_examples/unicode/test.py
+++ b/_examples/unicode/test.py
@@ -7,7 +7,16 @@
 ## py2/py3 compat
 from __future__ import print_function, unicode_literals
 
+import sys
+
 import encoding
+
+# There is no portable way of outputting Unicode in Python 2/3 -- we encode
+# them manually and sidestep the builtin encoding machinery
+try:
+    binary_stdout = sys.stdout.buffer  # Python 3
+except AttributeError:
+    binary_stdout = sys.stdout  # Python 2
 
 bytestr = b"Python byte string"
 unicodestr = u"Python Unicode string 🐱"
@@ -15,9 +24,15 @@ unicodestr = u"Python Unicode string 🐱"
 bytestr_ret = encoding.HandleString(bytestr)
 unicodestr_ret = encoding.HandleString(unicodestr)
 
-print("encoding.HandleString(bytestr) ->", bytestr_ret)
-print("encoding.HandleString(unicodestr) ->", unicodestr_ret)
+binary_stdout.write(b"encoding.HandleString(bytestr) -> ")
+binary_stdout.write(bytestr_ret.encode('UTF-8'))
+binary_stdout.write(b'\n')
+binary_stdout.write(b"encoding.HandleString(unicodestr) -> ")
+binary_stdout.write(unicodestr_ret.encode('UTF-8'))
+binary_stdout.write(b'\n')
 
 gostring_ret = encoding.GetString()
-print("encoding.GetString() ->", gostring_ret)
+binary_stdout.write(b"encoding.GetString() -> ")
+binary_stdout.write(gostring_ret.encode("UTF-8"))
+binary_stdout.write(b"\n")
 

--- a/_examples/vars/test.py
+++ b/_examples/vars/test.py
@@ -7,9 +7,9 @@ from __future__ import print_function
 
 import vars
 
-print("doc(vars):\n%s" % repr(vars.__doc__))
-print("doc(vars.GetV1()):\n%s" % repr(vars.GetV1.__doc__))
-print("doc(vars.SetV1()):\n%s" % repr(vars.SetV1.__doc__))
+print("doc(vars):\n%s" % repr(vars.__doc__).lstrip('u'))
+print("doc(vars.GetV1()):\n%s" % repr(vars.GetV1.__doc__).lstrip('u'))
+print("doc(vars.SetV1()):\n%s" % repr(vars.SetV1.__doc__).lstrip('u'))
 
 print("Initial values")
 print("v1 = %s" % vars.GetV1())
@@ -48,6 +48,6 @@ print("v7 = %s" % vars.GetV7())
 print("k1 = %s" % vars.GetKind1())
 print("k2 = %s" % vars.GetKind2())
 
-print("vars.GetDoc() = %s" % repr(vars.GetDoc()))
-print("doc of vars.GetDoc = %s" % (repr(vars.GetDoc.__doc__),))
-print("doc of vars.SetDoc = %s" % (repr(vars.SetDoc.__doc__),))
+print("vars.GetDoc() = %s" % repr(vars.GetDoc()).lstrip('u'))
+print("doc of vars.GetDoc = %s" % repr(vars.GetDoc.__doc__).lstrip('u'))
+print("doc of vars.SetDoc = %s" % repr(vars.SetDoc.__doc__).lstrip('u'))

--- a/bind/gencffi.go
+++ b/bind/gencffi.go
@@ -15,7 +15,8 @@ const (
 	//      #include "%[3]s.h"
 	//       """)
 	// discuss: https://github.com/go-python/gopy/pull/93#discussion_r119652220
-	cffiPreamble = `"""%[1]s"""
+	cffiPreamble = `%[1]s
+from __future__ import unicode_literals
 import collections
 import os
 import sys
@@ -157,8 +158,7 @@ class _cffi_helper(object):
         s = _cffi_helper.lib._cgopy_CString(c)
         pystr = ffi.string(s)
         _cffi_helper.lib._cgopy_FreeCString(s)
-        if _PY3:
-            pystr = pystr.decode('utf8')
+        pystr = pystr.decode('utf8')
         return pystr
 
     @staticmethod
@@ -166,8 +166,7 @@ class _cffi_helper(object):
         s = _cffi_helper.lib._cgopy_ErrorString(c)
         pystr = ffi.string(s)
         _cffi_helper.lib._cgopy_FreeCString(s)
-        if _PY3:
-            pystr = pystr.decode('utf8')
+        pystr = pystr.decode('utf8')
         return pystr
 
     @staticmethod
@@ -242,7 +241,11 @@ func (g *cffiGen) gen() error {
 func (g *cffiGen) genCffiPreamble() {
 	n := g.pkg.pkg.Name()
 	pkgDoc := g.pkg.doc.Doc
-	g.wrapper.Printf(cffiPreamble, pkgDoc, n)
+	if pkgDoc != "" {
+		g.wrapper.Printf(cffiPreamble, `"""`+pkgDoc+`"""`, n)
+	} else {
+		g.wrapper.Printf(cffiPreamble, "", n)
+	}
 }
 
 func (g *cffiGen) genCffiCdef() {

--- a/bind/gencffi.go
+++ b/bind/gencffi.go
@@ -87,8 +87,8 @@ class _cffi_helper(object):
 
     @staticmethod
     def cffi_cgopy_cnv_py2c_string(o):
-        if _PY3:
-            o = o.encode('ascii')
+        if (_PY3 and isinstance(o, str)) or (not _PY3 and isinstance(o, unicode)):
+            o = o.encode('utf8')
         s = ffi.new("char[]", o)
         return _cffi_helper.lib._cgopy_GoString(s)
 

--- a/bind/gencpy.go
+++ b/bind/gencpy.go
@@ -128,7 +128,7 @@ cgopy_cnv_py2c_string(PyObject *o, GoString *addr) {
 static PyObject*
 cgopy_cnv_c2py_string(GoString *addr) {
 	const char *str = _cgopy_CString(*addr);
-	PyObject *pystr = PyString_FromString(str);
+	PyObject *pystr = PyUnicode_FromString(str);
 	free((void*)str);
 	return pystr;
 }
@@ -298,10 +298,16 @@ func (g *cpyGen) gen() error {
 		)
 	}
 
-	g.impl.Printf("module = Py_InitModule3(%[1]q, cpy_%[1]s_methods, %[2]q);\n\n",
-		g.pkg.pkg.Name(),
-		g.pkg.doc.Doc,
-	)
+	if g.pkg.doc.Doc != "" {
+		g.impl.Printf("module = Py_InitModule3(%[1]q, cpy_%[1]s_methods, %[2]q);\n\n",
+			g.pkg.pkg.Name(),
+			g.pkg.doc.Doc,
+		)
+	} else {
+		g.impl.Printf("module = Py_InitModule3(%[1]q, cpy_%[1]s_methods, NULL);\n\n",
+			g.pkg.pkg.Name(),
+		)
+	}
 
 	for _, n := range g.pkg.syms.names() {
 		sym := g.pkg.syms.sym(n)

--- a/bind/gencpy.go
+++ b/bind/gencpy.go
@@ -103,11 +103,25 @@ cgopy_cnv_c2py_bool(GoUint8 *addr) {
 
 static int
 cgopy_cnv_py2c_string(PyObject *o, GoString *addr) {
-	const char *str = PyString_AsString(o);
-	if (str == NULL) {
-		return 0;
+	if (PyUnicode_Check(o)) {
+		o = PyUnicode_AsUTF8String(o);
+		if (o == NULL) {
+			return 0;
+		}
+		const char *str = PyString_AsString(o);
+		if (str == NULL) {
+			Py_DECREF(o);
+			return 0;
+		}
+		*addr = _cgopy_GoString((char*)str);
+		Py_DECREF(o);
+	} else {
+		const char *str = PyString_AsString(o);
+		if (str == NULL) {
+			return 0;
+		}
+		*addr = _cgopy_GoString((char*)str);
 	}
-	*addr = _cgopy_GoString((char*)str);
 	return 1;
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -213,6 +213,7 @@ var features = map[string][]string{
 	"_examples/maps":      []string{"py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 	"_examples/gostrings": []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 	"_examples/rename":    []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
+	"_examples/unicode":   []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
 }
 
 func TestHi(t *testing.T) {
@@ -873,6 +874,19 @@ func TestSlicePtr(t *testing.T) {
 		want: []byte(`sliceptr.IntVector{1, 2, 3}
 sliceptr.IntVector{1, 2, 3, 4}
 sliceptr.StrVector{"1", "2", "3", "4"}
+`),
+	})
+}
+
+func TestUnicode(t *testing.T) {
+	t.Parallel()
+	path := "_examples/unicode"
+	testPkg(t, pkg{
+		path: path,
+		lang: []string{"py2", "py2-cffi", "py3-cffi", "pypy2-cffi", "pypy3-cffi"},
+		want: []byte(`encoding.HandleString(bytestr) -> Python byte string
+encoding.HandleString(unicodestr) -> Python Unicode string 🐱
+encoding.GetString() -> Go Unicode string 🐱
 `),
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -681,7 +681,7 @@ func TestBindVars(t *testing.T) {
 		path: path,
 		lang: features[path],
 		want: []byte(`doc(vars):
-''
+None
 doc(vars.GetV1()):
 'returns vars.V1'
 doc(vars.SetV1()):


### PR DESCRIPTION
This PR builds on https://github.com/go-python/gopy/pull/170.

Currently, Python 3 CFFI returns Unicode, but Python 2 backends do not.

In Python 2, both byte and Unicode strings inherit from basestring and are interchangeable for most purposes. Some code might break, as Python 2 tries to encode Unicode strings to PYTHONIOENCODING while doing IO, and the specific encoding might be unable to represent the characters present in the string. Programs which ignore encoding _and_ have the need to output fancy characters suffer.

CPython 2 docstrings as Unicode are not implemented by this PR, but I do not think this is an issue.

Making the tests portable is difficult -- only the test for Unicode needs to handle IO encoding seriously. In the others I just strip the potential `u` which `repr` uses to mark Unicode strings in Python 2.