### PR TITLE
gopy/bind: enable subclassing of generated CPython objects

### DIFF
--- a/_examples/structs/test.py
+++ b/_examples/structs/test.py
@@ -53,3 +53,21 @@ try:
 except Exception as err:
     print("caught error: %s" % (err,))
     pass
+
+class S2Child(structs.S2):
+    def __init__(self, a, b):
+        super(S2Child, self).__init__(a)
+        self.local = b
+    def __str__(self):
+        return ("S2Child{S2: %s, local: %d}"
+                % (super(S2Child, self).__str__(), self.local))
+
+try:
+    s2child = S2Child(42, 123)
+    print("s2child = %s" % (s2child,))
+    print("s2child.Public = %s" % (s2child.Public,))
+    print("s2child.local = %s" % (s2child.local,))
+    print("s2child.private = %s" % (s2child.private,))
+except Exception as err:
+    print("caught error: %s" % (err,))
+    pass

--- a/bind/gencpy_struct.go
+++ b/bind/gencpy_struct.go
@@ -61,7 +61,7 @@ func (g *cpyGen) genStruct(cpy Struct) {
 	g.impl.Printf("0,\t/*tp_getattro*/\n")
 	g.impl.Printf("0,\t/*tp_setattro*/\n")
 	g.impl.Printf("0,\t/*tp_as_buffer*/\n")
-	g.impl.Printf("Py_TPFLAGS_DEFAULT,\t/*tp_flags*/\n")
+	g.impl.Printf("Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,\t/*tp_flags*/\n")
 	g.impl.Printf("%q,\t/* tp_doc */\n", cpy.Doc())
 	g.impl.Printf("0,\t/* tp_traverse */\n")
 	g.impl.Printf("0,\t/* tp_clear */\n")

--- a/main_test.go
+++ b/main_test.go
@@ -650,6 +650,10 @@ caught error: S2.__init__ takes at most 1 argument(s)
 s2 = structs.S2{Public:42, private:0}
 s2.Public = 42
 caught error: 'S2' object has no attribute 'private'
+s2child = S2Child{S2: structs.S2{Public:42, private:0}, local: 123}
+s2child.Public = 42
+s2child.local = 123
+caught error: 'S2Child' object has no attribute 'private'
 `),
 	})
 }


### PR DESCRIPTION
To mimic a SWIG library I'm porting, I'd like to inherit from GoPy-generated objects.

I believe that switching the flag should be everything that is necessary for this to work. GoPy objects do not serve as collections of Python objects, so handling GC is not needed and the lifecycle seems to be handled well enough so that no resources are leaked.