### PR TITLE
Added environment variable support

### DIFF
--- a/bind/utils.go
+++ b/bind/utils.go
@@ -97,14 +97,28 @@ func getPythonConfig(vm string) (pyconfig, error) {
 	code := `import sys
 import distutils.sysconfig as ds
 import json
-print(json.dumps({
-	"version": sys.version_info.major,
-	"incdir":  ds.get_python_inc(),
-	"libdir":  ds.get_config_var("LIBDIR"),
-	"libpy":   ds.get_config_var("LIBRARY"),
-	"shlibs":  ds.get_config_var("SHLIBS"),
-	"syslibs": ds.get_config_var("SYSLIBS"),
-	"shlinks": ds.get_config_var("LINKFORSHARED"),
+import os
+version=sys.version_info.major
+
+if "GOPY_INCLUDE" in os.environ and "GOPY_LIBDIR" in os.environ and "GOPY_PYLIB" in os.environ:
+	print(json.dumps({
+		"version": version,
+		"incdir": os.environ["GOPY_INCLUDE"],
+		"libdir": os.environ["GOPY_LIBDIR"],
+		"libpy": os.environ["GOPY_PYLIB"],
+		"shlibs":  ds.get_config_var("SHLIBS"),
+		"syslibs": ds.get_config_var("SYSLIBS"),
+		"shlinks": ds.get_config_var("LINKFORSHARED"),
+}))
+else:
+	print(json.dumps({
+		"version": sys.version_info.major,
+		"incdir":  ds.get_python_inc(),
+		"libdir":  ds.get_config_var("LIBDIR"),
+		"libpy":   ds.get_config_var("LIBRARY"),
+		"shlibs":  ds.get_config_var("SHLIBS"),
+		"syslibs": ds.get_config_var("SYSLIBS"),
+		"shlinks": ds.get_config_var("LINKFORSHARED"),
 }))
 `
 
@@ -138,6 +152,8 @@ print(json.dumps({
 	}
 
 	raw.IncDir = filepath.ToSlash(raw.IncDir)
+	raw.LibDir = filepath.ToSlash(raw.LibDir)
+
 	if strings.HasSuffix(raw.LibPy, ".a") {
 		raw.LibPy = raw.LibPy[:len(raw.LibPy)-len(".a")]
 	}

--- a/cmd_build.go
+++ b/cmd_build.go
@@ -6,15 +6,15 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"os/exec"
-	"strings"
-"runtime"
 	"github.com/go-python/gopy/bind"
 	"github.com/gonuts/commander"
 	"github.com/gonuts/flag"
-"path/filepath"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
 )
 
 func gopyMakeCmdBuild() *commander.Command {
@@ -171,11 +171,11 @@ func runBuild(mode bind.BuildMode, odir, outname, cmdstr, vm, mainstr string, sy
 			return err
 		}
 		cccmd := strings.TrimSpace(string(cccmdb))
-		var cflags , ldflags []byte
-		if runtime.GOOS!="windows" {
+		var cflags, ldflags []byte
+		if runtime.GOOS != "windows" {
 			fmt.Printf("%v-config --cflags\n", vm)
 			cmd = exec.Command(vm+"-config", "--cflags") // TODO: need minor version!
-			cflags, err= cmd.CombinedOutput()
+			cflags, err = cmd.CombinedOutput()
 			if err != nil {
 				fmt.Printf("cmd had error: %v  output:\n%v\n", err, string(cflags))
 				return err
@@ -189,31 +189,30 @@ func runBuild(mode bind.BuildMode, odir, outname, cmdstr, vm, mainstr string, sy
 				return err
 			}
 		}
-		extext:=libExt
-		if runtime.GOOS=="windows" {
-			extext=".pyd"
+		extext := libExt
+		if runtime.GOOS == "windows" {
+			extext = ".pyd"
 		}
 		modlib := "_" + outname + extext
 		gccargs := []string{outname + ".c", extraGccArgs, outname + "_go" + libExt, "-o", modlib}
 		gccargs = append(gccargs, strings.Split(strings.TrimSpace(string(cflags)), " ")...)
 		gccargs = append(gccargs, strings.Split(strings.TrimSpace(string(ldflags)), " ")...)
 		gccargs = append(gccargs, "-fPIC", "--shared", "-Ofast")
-		if !symbols { gccargs=append(gccargs, "-s") }
-		include, exists:=os.LookupEnv("GOPY_INCLUDE")
-		if exists {
-			gccargs=append(gccargs, "-I"+filepath.ToSlash(include))
+		if !symbols {
+			gccargs = append(gccargs, "-s")
 		}
-		lib, exists:=os.LookupEnv("GOPY_LIBDIR")
+		include, exists := os.LookupEnv("GOPY_INCLUDE")
 		if exists {
-			gccargs=append(gccargs, "-L"+filepath.ToSlash(lib))
+			gccargs = append(gccargs, "-I"+filepath.ToSlash(include))
 		}
-		libname, exists:=os.LookupEnv("GOPY_PYLIB")
+		lib, exists := os.LookupEnv("GOPY_LIBDIR")
 		if exists {
-			gccargs=append(gccargs, "-l"+filepath.ToSlash(libname))
+			gccargs = append(gccargs, "-L"+filepath.ToSlash(lib))
 		}
-
-
-
+		libname, exists := os.LookupEnv("GOPY_PYLIB")
+		if exists {
+			gccargs = append(gccargs, "-l"+filepath.ToSlash(libname))
+		}
 
 		gccargs = func(vs []string) []string {
 			o := make([]string, 0, len(gccargs))

--- a/cmd_build.go
+++ b/cmd_build.go
@@ -200,15 +200,15 @@ func runBuild(mode bind.BuildMode, odir, outname, cmdstr, vm, mainstr string, sy
 		gccargs = append(gccargs, "-fPIC", "--shared", "-Ofast")
 		if !symbols { gccargs=append(gccargs, "-s") }
 		include, exists:=os.LookupEnv("GOPY_INCLUDE")
-		if exists==true {
+		if exists {
 			gccargs=append(gccargs, "-I"+filepath.ToSlash(include))
 		}
 		lib, exists:=os.LookupEnv("GOPY_LIBDIR")
-		if exists==true {
+		if exists {
 			gccargs=append(gccargs, "-L"+filepath.ToSlash(lib))
 		}
 		libname, exists:=os.LookupEnv("GOPY_PYLIB")
-		if exists==true {
+		if exists {
 			gccargs=append(gccargs, "-l"+filepath.ToSlash(libname))
 		}
 


### PR DESCRIPTION
Currently, Gopy does not work easily on Windows.
While not automatically fixing that, this allows you to use environment variables to help Gopy find the include and lib dirs.
Also adds -Ofast flag when building Python extension module, in order to help performance a little bit.
Filepath.ToSlashes is also used for include and lib directories as it seems to be required.
The environment variables are:
GOPY_INCLUDE: The include directory where your Python headers are. For example: "C:\python38\include"
GOPY_LIBDIR: The folder where the Python development libraries are. Example: "C:\python38\libs".
GOPY_PYLIB: The name of the Python library to link against. It's what ever you put after the -l command if you manually compile extension modules using GCC. Example: "python37".
These are only used if all three of them are defined.
It is possible to set the environment variables only once, so it doesn't have to be changed every time you open a terminal.
Also should use .pyd extension now.
Right now, I can produce bindings with a package and load it directly from Python, with no need to change anything.
