### PR TITLE
fix tests to work with go modules

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -805,36 +805,17 @@ func testPkg(t *testing.T, table pkg) {
 	}
 }
 
-func copyPackage() (string, error) {
-	var err error
-	pkgCopyDir, err := ioutil.TempDir("", "gopy-")
-	if err != nil {
-		return "", err
-	}
-	target := filepath.Join(pkgCopyDir, "src", "github.com", "go-python", "gopy")
-	if err = os.MkdirAll(target, 0744); err != nil {
-		os.RemoveAll(pkgCopyDir)
-		return "", err
-	}
-	cmd := exec.Command("cp", "-r", ".", target)
-	if err := cmd.Run(); err != nil {
-		os.RemoveAll(pkgCopyDir)
-		return "", err
-	}
-	return pkgCopyDir, nil
-}
+func writeGoMod(t *testing.T, pkgDir, tstDir string) {
+	template := `
+module dummy
 
-func TestMain(m *testing.M) {
-	pkgCopyDir, err := copyPackage()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to install copy of gopy in a temp dir: %v", err)
-		os.Exit(1)
+require github.com/go-python/gopy v0.0.0
+replace github.com/go-python/gopy => %s
+`
+	contents := fmt.Sprintf(template, pkgDir)
+	if err := ioutil.WriteFile(filepath.Join(tstDir, "go.mod"), []byte(contents), 0666); err != nil {
+		t.Fatalf("failed to write go.mod file: %v", err)
 	}
-	testEnvironment = append(testEnvironment, "GOPATH="+pkgCopyDir)
-	fmt.Printf("gopy installed: %v\n", pkgCopyDir)
-	code := m.Run()
-	os.RemoveAll(pkgCopyDir)
-	os.Exit(code)
 }
 
 func testPkgBackend(t *testing.T, pyvm string, table pkg) {
@@ -852,6 +833,8 @@ func testPkgBackend(t *testing.T, pyvm string, table pkg) {
 	}
 	defer os.RemoveAll(workdir)
 	defer bind.ResetPackages()
+
+	writeGoMod(t, cwd, workdir)
 
 	// fmt.Printf("building in work dir: %s\n", workdir)
 	fpath := "./" + table.path


### PR DESCRIPTION
I noticed that gopy had to be in a GOPATH, pre modules, directory layout for the tests to work. This PR writes a dummy go.mod into the temp dirs created for the tests.