### PR TITLE
for slices with non-pointer struct element types, need to return pointer to element

### DIFF
--- a/bind/gen.go
+++ b/bind/gen.go
@@ -250,6 +250,7 @@ os.chdir(cwd)
 # %[2]s
 
 import _%[1]s, collections
+from enum import Enum
 
 # to use this code in your end-user python file, import it as follows:
 # from %[1]s import %[3]s
@@ -755,6 +756,11 @@ func (g *pyGen) genAll() {
 			continue
 		}
 		g.genType(sym, false, false) // not exttypes
+	}
+
+	g.pywrap.Printf("\n\n#---- Enums from Go (collections of consts with same type) ---\n")
+	for _, e := range g.pkg.enums {
+		g.genEnum(e)
 	}
 
 	g.pywrap.Printf("\n\n#---- Constants from Go: Python can only ask that you please don't change these! ---\n")

--- a/bind/gen_func.go
+++ b/bind/gen_func.go
@@ -221,7 +221,7 @@ func (g *pyGen) genMethod(s *symbol, o *Func) {
 
 func isIfaceHandle(gdoc string) (bool, string) {
 	const PythonIface = "\ngopy:interface=handle"
-	if idx := strings.Index(gdoc, PythonIface); idx > 0 {
+	if idx := strings.Index(gdoc, PythonIface); idx >= 0 {
 		gdoc = gdoc[:idx] + gdoc[idx+len(PythonIface)+1:]
 		return true, gdoc
 	}

--- a/bind/gen_func.go
+++ b/bind/gen_func.go
@@ -220,7 +220,7 @@ func (g *pyGen) genMethod(s *symbol, o *Func) {
 }
 
 func isIfaceHandle(gdoc string) (bool, string) {
-	const PythonIface = "\ngopy:interface=handle"
+	const PythonIface = "gopy:interface=handle"
 	if idx := strings.Index(gdoc, PythonIface); idx >= 0 {
 		gdoc = gdoc[:idx] + gdoc[idx+len(PythonIface)+1:]
 		return true, gdoc

--- a/bind/gen_map.go
+++ b/bind/gen_map.go
@@ -281,7 +281,7 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Printf("//export %s_len\n", slNm)
 		g.gofile.Printf("func %s_len(handle CGoHandle) int {\n", slNm)
 		g.gofile.Indent()
-		g.gofile.Printf("return len(*ptrFromHandle_%s(handle))\n", slNm)
+		g.gofile.Printf("return len(deptrFromHandle_%s(handle))\n", slNm)
 		g.gofile.Outdent()
 		g.gofile.Printf("}\n\n")
 
@@ -291,7 +291,7 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Printf("//export %s_elem\n", slNm)
 		g.gofile.Printf("func %s_elem(handle CGoHandle, _ky %s) %s {\n", slNm, ksym.cgoname, esym.cgoname)
 		g.gofile.Indent()
-		g.gofile.Printf("s := *ptrFromHandle_%s(handle)\n", slNm)
+		g.gofile.Printf("s := deptrFromHandle_%s(handle)\n", slNm)
 		if ksym.py2go != "" {
 			g.gofile.Printf("v, ok := s[%s(_ky)%s]\n", ksym.py2go, ksym.py2goParenEx)
 		} else {
@@ -316,7 +316,7 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Printf("//export %s_contains\n", slNm)
 		g.gofile.Printf("func %s_contains(handle CGoHandle, _ky %s) C.char {\n", slNm, ksym.cgoname)
 		g.gofile.Indent()
-		g.gofile.Printf("s := *ptrFromHandle_%s(handle)\n", slNm)
+		g.gofile.Printf("s := deptrFromHandle_%s(handle)\n", slNm)
 		if ksym.py2go != "" {
 			g.gofile.Printf("_, ok := s[%s(_ky)%s]\n", ksym.py2go, ksym.py2goParenEx)
 		} else {
@@ -332,7 +332,7 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Printf("//export %s_set\n", slNm)
 		g.gofile.Printf("func %s_set(handle CGoHandle, _ky %s, _vl %s) {\n", slNm, ksym.cgoname, esym.cgoname)
 		g.gofile.Indent()
-		g.gofile.Printf("s := *ptrFromHandle_%s(handle)\n", slNm)
+		g.gofile.Printf("s := deptrFromHandle_%s(handle)\n", slNm)
 		if ksym.py2go != "" {
 			g.gofile.Printf("s[%s(_ky)%s] = ", ksym.py2go, ksym.py2goParenEx)
 		} else {
@@ -352,7 +352,7 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Printf("//export %s_delete\n", slNm)
 		g.gofile.Printf("func %s_delete(handle CGoHandle, _ky %s) {\n", slNm, ksym.cgoname)
 		g.gofile.Indent()
-		g.gofile.Printf("s := *ptrFromHandle_%s(handle)\n", slNm)
+		g.gofile.Printf("s := deptrFromHandle_%s(handle)\n", slNm)
 		if ksym.py2go != "" {
 			g.gofile.Printf("delete(s, %s(_ky)%s)\n", ksym.py2go, ksym.py2goParenEx)
 		} else {
@@ -367,7 +367,7 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Printf("//export %s_keys\n", slNm)
 		g.gofile.Printf("func %s_keys(handle CGoHandle) CGoHandle {\n", slNm)
 		g.gofile.Indent()
-		g.gofile.Printf("s := *ptrFromHandle_%s(handle)\n", slNm)
+		g.gofile.Printf("s := deptrFromHandle_%s(handle)\n", slNm)
 		g.gofile.Printf("kys := make(%s, 0, len(s))\n", keyslsym.goname)
 		g.gofile.Printf("for k := range(s) {\n")
 		g.gofile.Indent()

--- a/bind/gen_slice.go
+++ b/bind/gen_slice.go
@@ -281,7 +281,11 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Indent()
 		g.gofile.Printf("s := *ptrFromHandle_%s(handle)\n", slNm)
 		if esym.go2py != "" {
-			g.gofile.Printf("return %s(s[_idx])%s\n", esym.go2py, esym.go2pyParenEx)
+			if !esym.isPointer() && esym.isStruct() {
+				g.gofile.Printf("return %s(&(s[_idx]))%s\n", esym.go2py, esym.go2pyParenEx)
+			} else {
+				g.gofile.Printf("return %s(s[_idx])%s\n", esym.go2py, esym.go2pyParenEx)
+			}
 		} else {
 			g.gofile.Printf("return s[_idx]\n")
 		}

--- a/bind/gen_slice.go
+++ b/bind/gen_slice.go
@@ -270,7 +270,7 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Printf("//export %s_len\n", slNm)
 		g.gofile.Printf("func %s_len(handle CGoHandle) int {\n", slNm)
 		g.gofile.Indent()
-		g.gofile.Printf("return len(*ptrFromHandle_%s(handle))\n", slNm)
+		g.gofile.Printf("return len(deptrFromHandle_%s(handle))\n", slNm)
 		g.gofile.Outdent()
 		g.gofile.Printf("}\n\n")
 
@@ -279,7 +279,7 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Printf("//export %s_elem\n", slNm)
 		g.gofile.Printf("func %s_elem(handle CGoHandle, _idx int) %s {\n", slNm, esym.cgoname)
 		g.gofile.Indent()
-		g.gofile.Printf("s := *ptrFromHandle_%s(handle)\n", slNm)
+		g.gofile.Printf("s := deptrFromHandle_%s(handle)\n", slNm)
 		if esym.go2py != "" {
 			if !esym.isPointer() && esym.isStruct() {
 				g.gofile.Printf("return %s(&(s[_idx]))%s\n", esym.go2py, esym.go2pyParenEx)
@@ -297,7 +297,7 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Printf("//export %s_set\n", slNm)
 		g.gofile.Printf("func %s_set(handle CGoHandle, _idx int, _vl %s) {\n", slNm, esym.cgoname)
 		g.gofile.Indent()
-		g.gofile.Printf("s := *ptrFromHandle_%s(handle)\n", slNm)
+		g.gofile.Printf("s := deptrFromHandle_%s(handle)\n", slNm)
 		if esym.py2go != "" {
 			g.gofile.Printf("s[_idx] = %s(_vl)%s\n", esym.py2go, esym.py2goParenEx)
 		} else {

--- a/bind/symbols.go
+++ b/bind/symbols.go
@@ -907,7 +907,7 @@ func (sym *symtab) addArrayType(pkg *types.Package, obj types.Object, t types.Ty
 		cpyname: PyHandle,
 		pysig:   "[]" + elsym.pysig,
 		go2py:   "handleFromPtr_" + id,
-		py2go:   "*ptrFromHandle_" + id,
+		py2go:   "deptrFromHandle_" + id,
 		zval:    "nil",
 	}
 	return nil
@@ -943,7 +943,7 @@ func (sym *symtab) addMapType(pkg *types.Package, obj types.Object, t types.Type
 		cpyname: PyHandle,
 		pysig:   "object",
 		go2py:   "handleFromPtr_" + id,
-		py2go:   "*ptrFromHandle_" + id,
+		py2go:   "deptrFromHandle_" + id,
 		zval:    "nil",
 	}
 	return nil
@@ -972,7 +972,7 @@ func (sym *symtab) addSliceType(pkg *types.Package, obj types.Object, t types.Ty
 		cpyname: PyHandle,
 		pysig:   "[]" + elsym.pysig,
 		go2py:   "handleFromPtr_" + id,
-		py2go:   "*ptrFromHandle_" + id,
+		py2go:   "deptrFromHandle_" + id,
 		zval:    "nil",
 	}
 	return nil


### PR DESCRIPTION
Pointer is needed so that elements can be modified -- no other way to do this python-side, and generated code assumes pointer receivers.

This has been fully tested on my extensive codebase..
