### PR TITLE
Update cmd_build.go

### DIFF
--- a/cmd_build.go
+++ b/cmd_build.go
@@ -230,7 +230,7 @@ func runBuild(mode bind.BuildMode, odir, outname, cmdstr, vm, mainstr string, sy
 		modlib := "_" + outname + extext
 		gccargs := []string{outname + ".c", extraGccArgs, outname + "_go" + libExt, "-o", modlib}
 		gccargs = append(gccargs, strings.Fields(pycfg.AllFlags())...)
-		gccargs = append(gccargs, "-fPIC", "--shared", "-Ofast")
+		gccargs = append(gccargs, "-Wl,-rpath=./", "-fPIC", "--shared", "-Ofast")
 		if !symbols {
 			gccargs = append(gccargs, "-s")
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-python/gopy
+module github.com/hhuangwx/gopy
 
 go 1.13
 


### PR DESCRIPTION
Add an option for the linker to find the shared object in the current path. This helps to avoid the setting of LD_LIBRARY_PATH