### PR TITLE
main: Use RPATH=$ORIGIN linker flag with python extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ package hi exposes a few Go functions to be wrapped and used from Python.
 ### From the command line
 
 ```sh
-$ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./
 $ gopy build -output=out -vm=`which python3` github.com/go-python/gopy/_examples/hi
 $ ls out
 Makefile  __init__.py  __pycache__/  _hi.so*  build.py  go.py  hi.c  hi.go  hi.py  hi_go.h  hi_go.so  patch-leaks.go

--- a/cmd_build.go
+++ b/cmd_build.go
@@ -232,6 +232,9 @@ func runBuild(mode bind.BuildMode, cfg *BuildCfg) error {
 		gccargs := []string{cfg.Name + ".c", extraGccArgs, cfg.Name + "_go" + libExt, "-o", modlib}
 		gccargs = append(gccargs, strings.Fields(pycfg.AllFlags())...)
 		gccargs = append(gccargs, "-fPIC", "--shared", "-Ofast")
+		if runtime.GOOS != "windows" {
+			gccargs = append(gccargs, "-Wl,-rpath=$ORIGIN")
+		}
 		if !cfg.Symbols {
 			gccargs = append(gccargs, "-s")
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -972,7 +972,7 @@ func testPkgBackend(t *testing.T, pyvm string, table pkg) {
 		tstDir = filepath.Join(workdir, pkgNm)
 	}
 	if table.testdir != "" {
-		tstDir = table.testdir
+		tstDir = filepath.Join(workdir, table.testdir)
 	}
 	tstSrc := filepath.Join(filepath.Join(cwd, table.path), "test.py")
 	tstDst := filepath.Join(tstDir, "test.py")

--- a/main_unix_test.go
+++ b/main_unix_test.go
@@ -7,7 +7,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -16,8 +15,6 @@ import (
 
 func init() {
 
-	// ld needs to look into the current directory to load the _go.so library
-	os.Setenv("LD_LIBRARY_PATH", fmt.Sprintf("%s:.", os.Getenv("LD_LIBRARY_PATH")))
 	testEnvironment = os.Environ()
 
 	var (


### PR DESCRIPTION
This commit adds a linker flags to the python extension to set the RPATH=$ORIGIN. Doing so removes the need to set LD_LIBRARY_PATH in both the runtime environment, and in the tests environment, in order for the python extension to find the neighboring Go shared library.

Replaces #243 
