### PR TITLE
Removed out-dated ref. to Google Groups. Replace with something else?

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ If you get a bunch of errors during linking in the build process, set `LIBDIR` o
 
 ## Community
 
-The `go-python` community can be reached out at [go-python@googlegroups.com](mailto:go-python@googlegroups.com) or via the web forum: [go-python group](https://groups.google.com/forum/#!forum/go-python).
 See the [CONTRIBUTING](https://github.com/go-python/gopy/blob/master/CONTRIBUTE.md) guide for pointers on how to contribute to `gopy`.
 
 ## Documentation


### PR DESCRIPTION
I deleted the outdated references from the linked issue.
Should this be replaced with a more up-to-date communication method or is it fine to leave it as is?
Closes #263 