### PR TITLE
feat: Add support for build tags

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,8 @@ type BuildCfg struct {
 	NoMake bool
 	// link resulting library dynamically
 	DynamicLinking bool
+	// BuildTags to be passed into `go build`.
+	BuildTags string
 }
 
 // NewBuildCfg returns a newly constructed build config


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

We need support for build tags when trying to link to a project that has a dependency on certain build flags (in our case, arrow).