### PR TITLE
Fixes #289

### DIFF
--- a/bind/utils.go
+++ b/bind/utils.go
@@ -109,6 +109,8 @@ import os
 version=sys.version_info.major
 
 def clear_ld_flags(s):
+	if s is None:
+		return ''
 	skip_first_word = s.split(' ', 1)[1]  # skip compiler name
 	skip_bundle = skip_first_word.replace('-bundle', '')  # cgo already passes -dynamiclib
 	return skip_bundle


### PR DESCRIPTION
It looks like Windows is returning `None` for `LDSHARED` which causes an exception.

This PR fixes this potential exception, by returning an empty string when `clear_ld_flags()` is getting `None`.

For more information see #289