### PR TITLE
fix: Add build tags to loadPackage

### DIFF
--- a/cmd_build.go
+++ b/cmd_build.go
@@ -73,7 +73,7 @@ func gopyRunCmdBuild(cmdr *commander.Command, args []string) error {
 	bind.NoMake = cfg.NoMake
 
 	for _, path := range args {
-		bpkg, err := loadPackage(path, true) // build first
+		bpkg, err := loadPackage(path, true, cfg.BuildTags) // build first
 		if err != nil {
 			return fmt.Errorf("gopy-gen: go build / load of package failed with path=%q: %v", path, err)
 		}

--- a/cmd_exe.go
+++ b/cmd_exe.go
@@ -133,7 +133,7 @@ func gopyRunCmdExe(cmdr *commander.Command, args []string) error {
 	}
 
 	for _, path := range args {
-		buildPkgRecurse(cfg.OutputDir, path, path, exmap)
+		buildPkgRecurse(cfg.OutputDir, path, path, exmap, cfg.BuildTags)
 	}
 	return runBuild(bind.ModeExe, cfg)
 }

--- a/cmd_gen.go
+++ b/cmd_gen.go
@@ -71,7 +71,7 @@ func gopyRunCmdGen(cmdr *commander.Command, args []string) error {
 	bind.NoMake = cfg.NoMake
 
 	for _, path := range args {
-		bpkg, err := loadPackage(path, true) // build first
+		bpkg, err := loadPackage(path, true, cfg.BuildTags) // build first
 		if err != nil {
 			return fmt.Errorf("gopy-gen: go build / load of package failed with path=%q: %v", path, err)
 		}

--- a/cmd_pkg.go
+++ b/cmd_pkg.go
@@ -129,14 +129,14 @@ func gopyRunCmdPkg(cmdr *commander.Command, args []string) error {
 	}
 
 	for _, path := range args {
-		buildPkgRecurse(cfg.OutputDir, path, path, exmap)
+		buildPkgRecurse(cfg.OutputDir, path, path, exmap, cfg.BuildTags)
 	}
 	return runBuild(bind.ModePkg, cfg)
 }
 
-func buildPkgRecurse(odir, path, rootpath string, exmap map[string]struct{}) error {
+func buildPkgRecurse(odir, path, rootpath string, exmap map[string]struct{}, buildTags string) error {
 	buildFirst := path == rootpath
-	bpkg, err := loadPackage(path, buildFirst)
+	bpkg, err := loadPackage(path, buildFirst, buildTags)
 	if err != nil {
 		return fmt.Errorf("gopy-gen: go build / load of package failed with path=%q: %v", path, err)
 	}
@@ -171,7 +171,7 @@ func buildPkgRecurse(odir, path, rootpath string, exmap map[string]struct{}) err
 			continue
 		}
 		sp := filepath.Join(path, dr)
-		buildPkgRecurse(odir, sp, rootpath, exmap)
+		buildPkgRecurse(odir, sp, rootpath, exmap, buildTags)
 	}
 	return nil
 }

--- a/gen.go
+++ b/gen.go
@@ -94,7 +94,8 @@ func loadPackage(path string, buildFirst bool, buildTags string) (*packages.Pack
 	if buildFirst {
 		args := []string{"build", "-v", "path"}
 		if buildTags != "" {
-			args = append(args, "-tags", buildTags)
+			buildTagStr := fmt.Sprintf("\"%s\"", strings.Join(strings.Split(buildTags, ","), ""))
+			args = append(args, "-tags", buildTagStr)
 		}
 		fmt.Printf("go %v\n", strings.Join(args, " "))
 		cmd := exec.Command("go", args...)

--- a/gen.go
+++ b/gen.go
@@ -94,7 +94,7 @@ func loadPackage(path string, buildFirst bool, buildTags string) (*packages.Pack
 	if buildFirst {
 		args := []string{"build", "-v", "path"}
 		if buildTags != "" {
-			buildTagStr := fmt.Sprintf("\"%s\"", strings.Join(strings.Split(buildTags, ","), ""))
+			buildTagStr := fmt.Sprintf("\"%s\"", strings.Join(strings.Split(buildTags, ","), " "))
 			args = append(args, "-tags", buildTagStr)
 		}
 		fmt.Printf("go %v\n", strings.Join(args, " "))

--- a/gen.go
+++ b/gen.go
@@ -92,11 +92,12 @@ func loadPackage(path string, buildFirst bool, buildTags string) (*packages.Pack
 	}
 
 	if buildFirst {
-		args := []string{"build", "-v", "path"}
+		args := []string{"build"}
 		if buildTags != "" {
 			buildTagStr := fmt.Sprintf("\"%s\"", strings.Join(strings.Split(buildTags, ","), " "))
 			args = append(args, "-tags", buildTagStr)
 		}
+		args = append(args, "-v", "path")
 		fmt.Printf("go %v\n", strings.Join(args, " "))
 		cmd := exec.Command("go", args...)
 		cmd.Stdin = os.Stdin

--- a/gen.go
+++ b/gen.go
@@ -85,14 +85,19 @@ func genPkg(mode bind.BuildMode, cfg *BuildCfg) error {
 	return err
 }
 
-func loadPackage(path string, buildFirst bool) (*packages.Package, error) {
+func loadPackage(path string, buildFirst bool, buildTags string) (*packages.Package, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
 	}
 
 	if buildFirst {
-		cmd := exec.Command("go", "build", "-v", path)
+		args := []string{"build", "-v", "path"}
+		if buildTags != "" {
+			args = append(args, "-tags", buildTags)
+		}
+		fmt.Printf("go %v\n", strings.Join(args, " "))
+		cmd := exec.Command("go", args...)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
If `buildFirst` flag is set when loading packages, makes sure that the build flags are imported correctly to prevent intermediate errors like these: 
<img width="1098" alt="Screen Shot 2022-07-14 at 2 21 43 PM" src="https://user-images.githubusercontent.com/7833572/179088340-2ad38eeb-597d-4251-8d81-1dd4a6bdc338.png">

Issue is resolved later when package is actually built but we're missing build tags beforehand.