### PR TITLE
fix broken link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Here's an example for how to use `setup.py` with gopy to make an installable pac
 https://github.com/natun-ai/labsdk/blob/master/setup.py
 
 Also, see this for cross-platform build:
-https://github.com/natun-ai/labsdk/blob/master/.github/workflows/wheels.yaml
+https://github.com/natun-ai/labsdk/blob/master/.github/workflows/release.yaml
 
 ## Troubleshooting
 


### PR DESCRIPTION
The cross-plaform example had changed the file name in https://github.com/dataploy-ai/labsdk/commit/b1a79b8b7422ad1e8d29f510ff5e975696ffbfde