### PR TITLE
gen symbol name use index to avoid illegal symobl name

### DIFF
--- a/bind/symbols.go
+++ b/bind/symbols.go
@@ -385,7 +385,7 @@ type symtab struct {
 	syms        map[string]*symbol
 	imports     map[string]string // key is full path, value is unique name
 	importNames map[string]string // package name to path map -- for detecting name conflicts
-	uniqName    byte              // char for making package name unique
+	uniqName    int               // index for making package name unique
 	parent      *symtab
 }
 
@@ -435,13 +435,11 @@ func (sym *symtab) addImport(pkg *types.Package) string {
 	}
 	ep, exists = sym.importNames[nm]
 	if exists && ep != p {
-		if sym.uniqName == 0 {
-			sym.uniqName = 'a'
-		} else {
+		if exists && ep != p {
 			sym.uniqName++
+			unm = fmt.Sprintf("s%d_%s", sym.uniqName, nm)
+			fmt.Printf("import conflict: existing: %s  new: %s  alias: %s\n", ep, p, unm)
 		}
-		unm = string([]byte{sym.uniqName}) + nm
-		fmt.Printf("import conflict: existing: %s  new: %s  alias: %s\n", ep, p, unm)
 	}
 	sym.importNames[unm] = p
 	sym.imports[p] = unm


### PR DESCRIPTION
when conflicting symbols exceeds, the generated symbol name will have control character. 