### PR TITLE
Fix - slice element is pyobject

### DIFF
--- a/_examples/slices/slices.go
+++ b/_examples/slices/slices.go
@@ -4,7 +4,10 @@
 
 package slices
 
-import "fmt"
+import (
+	"fmt"
+	"math/cmplx"
+)
 
 func IntSum(s []int) int {
 	sum := 0
@@ -28,6 +31,8 @@ type SliceInt16 []int16
 type SliceInt32 []int32
 type SliceInt64 []int64
 
+type SliceComplex []complex128
+
 type SliceIface []interface{}
 
 type S struct {
@@ -46,4 +51,12 @@ func PrintSSlice(ss []*S) {
 
 func PrintS(s *S) {
 	fmt.Printf("%v\n", s.Name)
+}
+
+func CmplxSqrt(arr SliceComplex) SliceComplex {
+	res := make([]complex128, len(arr))
+	for i, el := range arr {
+		res[i] = cmplx.Sqrt(el)
+	}
+	return res
 }

--- a/_examples/slices/test.py
+++ b/_examples/slices/test.py
@@ -3,6 +3,8 @@
 # license that can be found in the LICENSE file.
 
 from __future__ import print_function
+import math
+import random
 import slices, go
 
 a = [1,2,3,4]
@@ -34,5 +36,12 @@ slices.PrintSSlice(ss)
 
 slices.PrintS(ss[0])
 slices.PrintS(ss[1])
+
+cmplx = slices.SliceComplex([(random.random() + random.random() * 1j) for _ in range(16)])
+sqrts = slices.CmplxSqrt(cmplx)
+for root, orig in zip(sqrts, cmplx):
+    root_squared = root * root
+    assert math.isclose(root_squared.real, orig.real)
+    assert math.isclose(root_squared.imag, orig.imag)
 
 print("OK")

--- a/bind/gen_slice.go
+++ b/bind/gen_slice.go
@@ -313,7 +313,13 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Outdent()
 		g.gofile.Printf("}\n\n")
 
-		g.pybuild.Printf("mod.add_function('%s_elem', retval('%s'), [param('%s', 'handle'), param('int', 'idx')])\n", slNm, esym.cpyname, PyHandle)
+		var caller_owns_ret string
+		var transfer_ownership string
+		if esym.cpyname == "PyObject*" {
+			caller_owns_ret = ", caller_owns_return=True"
+			transfer_ownership = ", transfer_ownership=False"
+		}
+		g.pybuild.Printf("mod.add_function('%s_elem', retval('%s'%s), [param('%s', 'handle'), param('int', 'idx')])\n", slNm, esym.cpyname, caller_owns_ret, PyHandle)
 
 		if slc.isSlice() {
 			g.gofile.Printf("//export %s_subslice\n", slNm)
@@ -340,7 +346,7 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Outdent()
 		g.gofile.Printf("}\n\n")
 
-		g.pybuild.Printf("mod.add_function('%s_set', None, [param('%s', 'handle'), param('int', 'idx'), param('%v', 'value')])\n", slNm, PyHandle, esym.cpyname)
+		g.pybuild.Printf("mod.add_function('%s_set', None, [param('%s', 'handle'), param('int', 'idx'), param('%v', 'value'%s)])\n", slNm, PyHandle, esym.cpyname, transfer_ownership)
 
 		if slc.isSlice() {
 			g.gofile.Printf("//export %s_append\n", slNm)
@@ -355,7 +361,7 @@ otherwise parameter is a python list that we copy from
 			g.gofile.Outdent()
 			g.gofile.Printf("}\n\n")
 
-			g.pybuild.Printf("mod.add_function('%s_append', None, [param('%s', 'handle'), param('%s', 'value')])\n", slNm, PyHandle, esym.cpyname)
+			g.pybuild.Printf("mod.add_function('%s_append', None, [param('%s', 'handle'), param('%s', 'value'%s)])\n", slNm, PyHandle, esym.cpyname, transfer_ownership)
 		}
 	}
 }


### PR DESCRIPTION
When a slice element is a `PyObject*` pybindgen needs to know the ownership details.