### PR TITLE
Fixes a leftover bug to properly handle multiple go packages when gen…

### DIFF
--- a/bind/gen.go
+++ b/bind/gen.go
@@ -552,7 +552,11 @@ func (g *pyGen) genPkgWrapOut() {
 	impstr := ""
 	for _, im := range g.pkg.pyimports {
 		if g.mode == ModeGen || g.mode == ModeBuild {
-			impstr += fmt.Sprintf("import %s\n", im)
+			if g.cfg.PkgPrefix != "" {
+				impstr += fmt.Sprintf("from %s import %s\n", g.cfg.PkgPrefix, im)
+			} else {
+				impstr += fmt.Sprintf("import %s\n", im)
+			}
 		} else {
 			impstr += fmt.Sprintf("from %s import %s\n", g.cfg.Name, im)
 		}


### PR DESCRIPTION
Fixes a leftover bug to properly handle multiple go packages when generating python relative imports.

Refs go-python/gopy #245