### PR TITLE
Fix: mixed absolute and relative imports

### DIFF
--- a/bind/gen.go
+++ b/bind/gen.go
@@ -551,7 +551,7 @@ func (g *pyGen) genPkgWrapOut() {
 	// note: must generate import string at end as imports can be added during processing
 	impstr := ""
 	for _, im := range g.pkg.pyimports {
-		if g.mode == ModeGen || g.mode == ModeBuild {
+		if g.mode == ModeGen || g.mode == ModeBuild || g.mode == ModePkg {
 			if g.cfg.PkgPrefix != "" {
 				impstr += fmt.Sprintf("from %s import %s\n", g.cfg.PkgPrefix, im)
 			} else {
@@ -653,7 +653,7 @@ func (g *pyGen) genPyWrapPreamble() {
 			impgenstr += fmt.Sprintf("import %s\n", "_"+g.cfg.Name)
 		}
 		impstr += fmt.Sprintf(GoPkgDefs, g.cfg.Name)
-	case g.mode == ModeGen || g.mode == ModeBuild:
+	case g.mode == ModeGen || g.mode == ModeBuild || g.mode == ModePkg:
 		if g.cfg.PkgPrefix != "" {
 			for _, name := range impgenNames {
 				impgenstr += fmt.Sprintf("from %s import %s\n", g.cfg.PkgPrefix, name)


### PR DESCRIPTION
## Problem

Command `pkg` creates a mix of absolute and relative imports that make using the Python package impossible. See #309.

## Solution

Handle imports for command `pkg` the same as `build` and `exe`.
For the default `PkgPrefix` (`.`), all imports now look like this:

```python
from . import xxx
```

## Notes

Not sure why it was implemented differently for `pkg` compared to `build` and `exe`, so my approach may not be valid. However, it could also be a leftover bug from #245, #301 and #302.

Fixes #309