### PR TITLE
Fix: Broken with Go 1.20 - quoted path

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -97,7 +97,7 @@ func loadPackage(path string, buildFirst bool, buildTags string) (*packages.Pack
 			buildTagStr := fmt.Sprintf("\"%s\"", strings.Join(strings.Split(buildTags, ","), " "))
 			args = append(args, "-tags", buildTagStr)
 		}
-		args = append(args, "-v", "path")
+		args = append(args, "-v", path)
 		fmt.Printf("go %v\n", strings.Join(args, " "))
 		cmd := exec.Command("go", args...)
 		cmd.Stdin = os.Stdin


### PR DESCRIPTION
Remove quotes from path when compiling package.

I.e., go was called as `go build -v path` (with "path" instead of the actual path).

Broke package extraction in Go 1.20.
I have no idea why it worked at all in Go 1.19.

Fixes #311