### PR TITLE
Enforce the extension module in setup.py

### DIFF
--- a/pkgsetup.go
+++ b/pkgsetup.go
@@ -19,6 +19,12 @@ const (
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+
+class BinaryDistribution(setuptools.Distribution):
+    def has_ext_modules(_):
+        return True
+
+
 setuptools.setup(
     name="%[1]s%[2]s",
     version="%[3]s",
@@ -35,6 +41,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     include_package_data=True,
+    distclass=BinaryDistribution,
 )
 `
 


### PR DESCRIPTION
Without this change, [cibuildwheel](https://github.com/pypa/cibuildwheel) cannot build a correct wheel from the generated project. The problem is that the native lib is added by `MANIFEST.in` and `python3 -m pip wheel` ignores it and thinks that the package is pure Python. Therefore it builds a pure wheel and the packaging pipeline crashes.