### PR TITLE
bind: fixed LDFLAGS on windows if python include path contains capital letters

### DIFF
--- a/bind/utils.go
+++ b/bind/utils.go
@@ -186,11 +186,10 @@ else:
 	raw.LibDir = filepath.ToSlash(raw.LibDir)
 
 	// on windows these can be empty -- use include dir which is usu good
+	// replace suffix case insensitive 'include' with 'libs'
 	if raw.LibDir == "" && raw.IncDir != "" {
-		raw.LibDir = raw.IncDir
-		if strings.HasSuffix(raw.LibDir, "include") {
-			raw.LibDir = raw.LibDir[:len(raw.LibDir)-len("include")] + "libs"
-		}
+		regexInc := regexp.MustCompile(`(?i)\binclude$`)
+		raw.LibDir = regexInc.ReplaceAllString(raw.IncDir, "libs")
 		fmt.Printf("no LibDir -- copy from IncDir: %s\n", raw.LibDir)
 	}
 


### PR DESCRIPTION
On Windows, python include folder may contain upper cases, here's an example generate the wrong LDFLAGS with gopy v0.4.7
```go
#cgo CFLAGS: -IC:/Users/test/miniconda3/envs/test/Include -Wno-error -Wno-implicit-function-declaration -Wno-int-conversion
#cgo LDFLAGS: -LC:/Users/test/miniconda3/envs/test/Include -lpython310
```
after the fix, it can works well on my environment
```go
#cgo CFLAGS: -IC:/Users/test/miniconda3/envs/test/Include -Wno-error -Wno-implicit-function-declaration -Wno-int-conversion
#cgo LDFLAGS: -LC:/Users/test/miniconda3/envs/test/libs -lpython310
```

Here're the console logs
```bash
--- Processing package: test/pkg/py ---
no LibDir -- copy from IncDir: C:/Users/test/miniconda3/envs/test/libs
```

fix #325 