### PR TITLE
fix __next__ function

### DIFF
--- a/bind/gen_slice.go
+++ b/bind/gen_slice.go
@@ -246,7 +246,11 @@ otherwise parameter is a python list that we copy from
 		g.pywrap.Indent()
 		g.pywrap.Printf("if self.index < len(self):\n")
 		g.pywrap.Indent()
-		g.pywrap.Printf("rv = _%s_elem(self.handle, self.index)\n", qNm)
+		if esym.hasHandle() {
+			g.pywrap.Printf("rv = %s(handle=_%s_elem(self.handle, self.index))\n", esym.pyPkgId(slc.gopkg), qNm)
+		} else {
+			g.pywrap.Printf("rv = _%s_elem(self.handle, self.index)\n", qNm)
+		}
 		g.pywrap.Println("self.index = self.index + 1")
 		g.pywrap.Println("return rv")
 		g.pywrap.Outdent()

--- a/main_test.go
+++ b/main_test.go
@@ -593,7 +593,7 @@ slices.IntSum from Python list: 10
 slices.IntSum from Go slice: 10
 unsigned slice elements: 1 2 3 4
 signed slice elements: -1 -2 -3 -4
-struct slice:  slices.Slice_Ptr_slices_S len: 3 handle: 11 [12, 13, 14]
+struct slice:  slices.Slice_Ptr_slices_S len: 3 handle: 11 [slices.S{Name=S0, handle=12}, slices.S{Name=S1, handle=13}, slices.S{Name=S2, handle=14}]
 struct slice[0]:  slices.S{Name=S0, handle=15}
 struct slice[1]:  slices.S{Name=S1, handle=16}
 struct slice[2].Name:  S2


### PR DESCRIPTION
Previously, it was not possible to iterate using the `for ... in ...` command in Python as shown below:

```python
# Library generated by gopy
from hltvsdk import operations

# `matches` is of the slice type
matches = operations.GetMatches()

for m in matches:
    print(m.Team1)
```

The code above resulted in the following error:

```
Traceback (most recent call last):
  File "/home/richecr/open_source/hltvgo/test.py", line 6, in <module>
    print(m.Team1)
          ^^^^
AttributeError: 'int' object has no attribute 'Team1'
```

My fix addresses this issue. The solution essentially involved replicating the code generation as performed in the `__getitem__` method.