### PR TITLE
Efficient copies of bytes

### DIFF
--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -11,6 +11,7 @@ _examples/consts | yes
 _examples/cstrings | yes
 _examples/empty | yes
 _examples/funcs | yes
+_examples/gobytes | yes
 _examples/gopygc | yes
 _examples/gostrings | yes
 _examples/hi | yes

--- a/_examples/gobytes/gobytes.go
+++ b/_examples/gobytes/gobytes.go
@@ -1,0 +1,33 @@
+// Copyright 2017 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gobytes
+
+func HashBytes(b []byte) [4]byte {
+	result := [4]byte{0, 0, 0, 0}
+	full_blocks := len(b) / 4
+	for i := 0; i < full_blocks; i++ {
+		for j := 0; j < 4; j++ {
+			result[j] ^= b[4*i+j]
+		}
+	}
+	if full_blocks*4 < len(b) {
+		for j := 0; j < 4; j++ {
+			if full_blocks*4+j < len(b) {
+				result[j] ^= b[full_blocks*4+j]
+			} else {
+				result[j] ^= 0x55
+			}
+		}
+	}
+	return result
+}
+
+func CreateBytes(len byte) []byte {
+	res := make([]byte, len)
+	for i := (byte)(0); i < len; i++ {
+		res[i] = i
+	}
+	return res
+}

--- a/_examples/gobytes/test.py
+++ b/_examples/gobytes/test.py
@@ -1,0 +1,18 @@
+# Copyright 2017 The go-python Authors.  All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from __future__ import print_function
+import gobytes, go
+
+a = bytes([0, 1, 2, 3])
+b = gobytes.CreateBytes(10)
+print ("Python bytes:", a)
+print ("Go slice: ", b)
+
+print ("gobytes.HashBytes from Go bytes:", gobytes.HashBytes(b))
+
+print("Python bytes to Go: ", go.Slice_byte.from_bytes(a))
+print("Go bytes to Python: ", bytes(go.Slice_byte([3, 4, 5])))
+
+print("OK")

--- a/main_test.go
+++ b/main_test.go
@@ -23,6 +23,7 @@ var (
 	testBackends = map[string]string{}
 	features     = map[string][]string{
 		"_examples/hi":          []string{"py3"},
+		"_examples/gobytes":     []string{"py3"},
 		"_examples/funcs":       []string{"py3"},
 		"_examples/sliceptr":    []string{"py3"},
 		"_examples/simple":      []string{"py3"},
@@ -261,6 +262,25 @@ slice: go.Slice_int len: 2 handle: 300037 [1, 42]
 slice repr: go.Slice_int([1, 42])
 len(slice): 2
 mem(slice): caught: memoryview: a bytes-like object is required, not 'Slice_int'
+OK
+`),
+	})
+
+}
+
+func TestBytes(t *testing.T) {
+	// t.Parallel()
+	path := "_examples/gobytes"
+	testPkg(t, pkg{
+		path:   path,
+		lang:   features[path],
+		cmd:    "build",
+		extras: nil,
+		want: []byte(`Python bytes: b'\x00\x01\x02\x03'
+Go slice:  go.Slice_byte len: 10 handle: 1 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+gobytes.HashBytes from Go bytes: gobytes.Array_4_byte len: 4 handle: 2 [12, 13, 81, 81]
+Python bytes to Go:  go.Slice_byte len: 4 handle: 3 [0, 1, 2, 3]
+Go bytes to Python:  b'\x03\x04\x05'
 OK
 `),
 	})


### PR DESCRIPTION
This aims to solve both #323 and #328 by supplying efficient methods to copy Python `bytes` into Go `[]byte` slices and vice versa.

One question I have is whether the `Slice_byte` Python constructor should check if the first argument is of type `bytes`, and if so use the optimized method?