### PR TITLE
fix panic when packaged go code relies on structural typing

### DIFF
--- a/bind/package.go
+++ b/bind/package.go
@@ -337,8 +337,15 @@ func (p *Package) process() error {
 			funcs[name] = fv
 
 		case *types.TypeName:
-			named := obj.Type().(*types.Named)
-			switch typ := named.Underlying().(type) {
+			typ := obj.Type()
+			if named, ok := typ.(*types.Named); ok {
+				typ = named.Underlying()
+			} else {
+				// we are dealing with a type alias to a type literal.
+				// this is a cursed feature used to do structural typing.
+				// just pass it as-is.
+			}
+			switch typ := typ.(type) {
 			case *types.Struct:
 				sv, err := newStruct(p, obj)
 				if err != nil {


### PR DESCRIPTION
Fix this panic:
```
panic: interface conversion: types.Type is *types.Signature, not *types.Named

goroutine 1 [running]:
github.com/go-python/gopy/bind.(*Package).process(0xc01d5ee800)
	/home/hugo/k/gopy/bind/package.go:340 +0x2078
github.com/go-python/gopy/bind.NewPackage(0xc009d2e720, 0xc00b228120)
	/home/hugo/k/gopy/bind/package.go:68 +0x27c
main.parsePackage(0xc0203ec180)
	/home/hugo/k/gopy/gen.go:159 +0x276
main.buildPkgRecurse({0xc0000ce640, 0x20}, {0xc0005d1ce0, 0x26}, {0x7ffd641ad938, 0x1b}, 0xc00d08bc68, {0x0, 0x0})
	/home/hugo/k/gopy/cmd_pkg.go:162 +0x2b6
main.buildPkgRecurse({0xc0000ce640, 0x20}, {0xc01173e280, 0x20}, {0x7ffd641ad938, 0x1b}, 0xc00d08bc68, {0x0, 0x0})
	/home/hugo/k/gopy/cmd_pkg.go:174 +0x428
main.buildPkgRecurse({0xc0000ce640, 0x20}, {0x7ffd641ad938, 0x1b}, {0x7ffd641ad938, 0x1b}, 0xc00d08bc68, {0x0, 0x0})
	/home/hugo/k/gopy/cmd_pkg.go:174 +0x428
main.gopyRunCmdPkg(0xc00012cd20, {0xc00009e230, 0x1, 0x747468?})
	/home/hugo/k/gopy/cmd_pkg.go:132 +0xd19
github.com/gonuts/commander.(*Command).Dispatch(0xc00012cd20, {0xc00009e230, 0x1, 0x1})
	/home/hugo/go/pkg/mod/github.com/gonuts/commander@v0.1.0/commands.go:209 +0x170
github.com/gonuts/commander.(*Command).Dispatch(0xc00012cf00, {0xc00009e220, 0x2, 0x2})
	/home/hugo/go/pkg/mod/github.com/gonuts/commander@v0.1.0/commands.go:175 +0x22f
main.run({0xc00009e220, 0x2, 0x2})
	/home/hugo/k/gopy/main.go:62 +0x25b
main.main()
	/home/hugo/k/gopy/main.go:70 +0x49
```
When packaing code like this
```go
type Public = func()
```