### PR TITLE
Fix `handleFromPtr` missing Reference in Maps

### DIFF
--- a/bind/gen_map.go
+++ b/bind/gen_map.go
@@ -303,7 +303,7 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Outdent()
 		g.gofile.Printf("}\n")
 		if esym.go2py != "" {
-			g.gofile.Printf("return %s(v)%s\n", esym.go2py, esym.go2pyParenEx)
+			g.gofile.Printf("return %s(&v)%s\n", esym.go2py, esym.go2pyParenEx)
 		} else {
 			g.gofile.Printf("return v\n")
 		}

--- a/bind/gen_map.go
+++ b/bind/gen_map.go
@@ -303,7 +303,14 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Outdent()
 		g.gofile.Printf("}\n")
 		if esym.go2py != "" {
-			g.gofile.Printf("return %s(&v)%s\n", esym.go2py, esym.go2pyParenEx)
+			// If the go2py starts with handleFromPtr_, use &v, otherwise just v
+			val_str := ""
+			if strings.HasPrefix(esym.go2py, "handleFromPtr_") {
+				val_str = "&v"
+			} else {
+				val_str = "v"
+			}
+			g.gofile.Printf("return %s(%s)%s\n", esym.go2py, val_str, esym.go2pyParenEx)
 		} else {
 			g.gofile.Printf("return v\n")
 		}


### PR DESCRIPTION
This patch fixes a `panic` I was encountering when using a map whose value was a non-value-type like another Map, Struct, Slice, etc.

Related:

- #346 
- #329 
- [Commit ](https://github.com/richecr/gopy/commit/92d159f53618f6df6857069e49109b16058e1f66) by @richecr that fixed a similar issue for slices

This fix makes `gopy` useable for me but I have not added new tests (yet)