### PR TITLE
Adds missing pointer reference for slices along with test

### DIFF
--- a/_examples/slices/slices.go
+++ b/_examples/slices/slices.go
@@ -60,3 +60,16 @@ func CmplxSqrt(arr SliceComplex) SliceComplex {
 	}
 	return res
 }
+
+func GetEmptyMatrix(xSize int, ySize int) [][]bool {
+	result := [][]bool{}
+
+	for i := 0; i < xSize; i++ {
+		result = append(result, []bool{})
+		for j := 0; j < ySize; j++ {
+			result[i] = append(result[i], false)
+		}
+	}
+
+	return result
+}

--- a/_examples/slices/test.py
+++ b/_examples/slices/test.py
@@ -44,4 +44,11 @@ for root, orig in zip(sqrts, cmplx):
     assert math.isclose(root_squared.real, orig.real)
     assert math.isclose(root_squared.imag, orig.imag)
 
+
+matrix = slices.GetEmptyMatrix(4,4)
+for i in range(4):
+    for j in range(4):
+        assert not matrix[i][j]
+print("[][]bool working as expected")
+
 print("OK")

--- a/bind/gen_slice.go
+++ b/bind/gen_slice.go
@@ -325,11 +325,14 @@ otherwise parameter is a python list that we copy from
 		g.gofile.Indent()
 		g.gofile.Printf("s := deptrFromHandle_%s(handle)\n", slNm)
 		if esym.go2py != "" {
-			if !esym.isPointer() && esym.isStruct() {
-				g.gofile.Printf("return %s(&(s[_idx]))%s\n", esym.go2py, esym.go2pyParenEx)
+			// If the go2py starts with handleFromPtr_, use reference &, otherwise just return the value
+			val_str := ""
+			if strings.HasPrefix(esym.go2py, "handleFromPtr_") {
+				val_str = "&(s[_idx])"
 			} else {
-				g.gofile.Printf("return %s(s[_idx])%s\n", esym.go2py, esym.go2pyParenEx)
+				val_str = "s[_idx]"
 			}
+			g.gofile.Printf("return %s(%s)%s\n", esym.go2py, val_str, esym.go2pyParenEx)
 		} else {
 			g.gofile.Printf("return s[_idx]\n")
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -616,6 +616,7 @@ struct slice:  slices.Slice_Ptr_slices_S len: 3 handle: 11 [slices.S{Name=S0, ha
 struct slice[0]:  slices.S{Name=S0, handle=15}
 struct slice[1]:  slices.S{Name=S1, handle=16}
 struct slice[2].Name:  S2
+[][]bool working as expected
 OK
 `),
 	})


### PR DESCRIPTION
Fixes #346 

NOTE: The variadic test was failing for me before adding this test:

<details>
  <summary>Click me</summary>

```
run cmd: [build -vm=python3 -output=/tmp/gopy-3250023487 -package-prefix  ./_examples/variadic]
go build -v ./_examples/variadic

--- Processing package: github.com/go-python/gopy/_examples/variadic ---

--- building package ---
gopy.test -test.paniconexit0 -test.timeout=10m0s
goimports -w variadic.go
go build -mod=mod -buildmode=c-shared -o variadic_go.so .
/home/evan/miniconda3/bin/python3 build.py
CGO_CFLAGS="-I/home/evan/miniconda3/include/python3.10" -fPIC -Ofast
CGO_LDFLAGS="-L/home/evan/miniconda3/lib" "-lpython3.10" -lcrypt -lpthread -ldl -lutil -lm -lm
go build -mod=mod -buildmode=c-shared -o _variadic.cpython-310-x86_64-linux-gnu.so .
running python3 test.py
FAIL
exit status 1
FAIL    github.com/go-python/gopy       123.954s
```

</details>

Is that test flaky for other people too?

However I did confirm that the new test I added failed before the fix and passed afterwards. 