### PR TITLE
Replacement c.long(size) for c.longlong(size)

### DIFF
--- a/bind/gen_slice.go
+++ b/bind/gen_slice.go
@@ -406,7 +406,7 @@ otherwise parameter is a python list that we copy from
 			g.gofile.Printf("s := deptrFromHandle_Slice_byte(handle)\n")
 			g.gofile.Printf("ptr := unsafe.Pointer(&s[0])\n")
 			g.gofile.Printf("size := len(s)\n")
-			g.gofile.Printf("return C.PyBytes_FromStringAndSize((*C.char)(ptr), C.long(size))\n")
+			g.gofile.Printf("return C.PyBytes_FromStringAndSize((*C.char)(ptr), C.longlong(size))\n")
 			g.gofile.Outdent()
 			g.gofile.Printf("}\n\n")
 


### PR DESCRIPTION
修复 python 3.12 版本无法编译的Bug
原生成后代码:
```golang
func Slice_byte_to_bytes(handle CGoHandle) *C.PyObject {
	s := deptrFromHandle_Slice_byte(handle)
	ptr := unsafe.Pointer(&s[0])
	size := len(s)
	return C.PyBytes_FromStringAndSize((*C.char)(ptr), C.long(size))
}
```
替换此例子中的C.long为C.longlong
实测修复后gopy build 正常