### PR TITLE
build: Append existing CFLAGS and LDFLAGS for CGO

### DIFF
--- a/cmd_build.go
+++ b/cmd_build.go
@@ -235,6 +235,9 @@ func runBuild(mode bind.BuildMode, cfg *BuildCfg) error {
 		if include, exists := os.LookupEnv("GOPY_INCLUDE"); exists {
 			cflags = append(cflags, "-I"+filepath.ToSlash(include))
 		}
+		if oldcflags, exists := os.LookupEnv("CGO_CFLAGS"); exists {
+			cflags = append(cflags, oldcflags)
+		}
 		var ldflags []string
 		if cfg.DynamicLinking {
 			ldflags = strings.Fields(strings.TrimSpace(pycfg.LdDynamicFlags))
@@ -249,6 +252,9 @@ func runBuild(mode bind.BuildMode, cfg *BuildCfg) error {
 		}
 		if libname, exists := os.LookupEnv("GOPY_PYLIB"); exists {
 			ldflags = append(ldflags, "-l"+filepath.ToSlash(libname))
+		}
+		if oldldflags, exists := os.LookupEnv("CGO_LDFLAGS"); exists {
+			ldflags = append(ldflags, oldldflags)
 		}
 
 		removeEmpty := func(src []string) []string {


### PR DESCRIPTION
Underlying `go build` commands can pass custom `CFLAGS` and `LDFLAGS` to CGO invocations, which GoPy uses in order to pass some of its own command-line arguments to builds.

However, there are cases where additional, build-specific parameters may need to be used (e.g. in the case where we're linking against a static library which itself links to other dynamic libraries, which aren't set as options in the packages themselves); this commit respects any existing uses of the `CGO_CFLAGS` and `CGO_LDFLAGS` environment variables, and appends their values to ones used internally by GoPy if needed.

My own, specific use-case here is using GoPy in [`slidge-whatsapp`](https://git.sr.ht/~nicoco/slidge-whatsapp), and using [`go-fitz`](https://github.com/gen2brain/go-fitz), which links against `libmupdf`, which in turn requires a number of different libraries (`libjpeg`, `libharfbuzz`, etc.)

Infuriatingly enough, Debian doesn't provide a package containing a shared library for MuPDF, only a [static library](https://packages.debian.org/bookworm/libmupdf-dev), which requires that we declare any shared libraries specifically at the time of compilation; otherwise builds work but you get `undefined reference` errors at runtime.