### PR TITLE
Add freebsd to main_unix.go

### DIFF
--- a/main_unix.go
+++ b/main_unix.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (linux && !android) || dragonfly || openbsd
-// +build linux,!android dragonfly openbsd
+//go:build (linux && !android) || dragonfly || openbsd || freebsd
+// +build linux,!android dragonfly openbsd freebsd
 
 package main
 


### PR DESCRIPTION
Add freebsd to main_unix.go, as without it building will fail as libExt and extraGccArgs are undefined