### PR TITLE
Migrate clang call from deprecated '-Ofast' to '-O3 -ffast-math'

### DIFF
--- a/cmd_build.go
+++ b/cmd_build.go
@@ -231,7 +231,7 @@ func runBuild(mode bind.BuildMode, cfg *BuildCfg) error {
 		}
 
 		cflags := strings.Fields(strings.TrimSpace(pycfg.CFlags))
-		cflags = append(cflags, "-fPIC", "-Ofast")
+		cflags = append(cflags, "-fPIC", "-O3", "-ffast-math")
 		if include, exists := os.LookupEnv("GOPY_INCLUDE"); exists {
 			cflags = append(cflags, "-I"+filepath.ToSlash(include))
 		}


### PR DESCRIPTION
Fix deprecation error in clang 
```
clang: error: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations [-Werror,-Wdeprecated-ofast]
```

Closes #371 