### PR TITLE
Update Versions in GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,18 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: [1.22.x, 1.21.x]
+        go-version: [1.24.x, 1.21.x]
         platform: [ubuntu-latest]
         #platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
  
     - name: Cache-Go
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: |
             ~/go/pkg/mod              # Module download cache
@@ -45,7 +45,7 @@ jobs:
           ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
  
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install Linux packages
       if: matrix.platform == 'ubuntu-latest'


### PR DESCRIPTION
Lowest of the low hanging fruit, but this should make the GitHub action output a bit more useful. 
Didn't touch appveyor because I know too little about it.

Also bumped go version 1.22 to most recent (major) release