### PR TITLE
Fix compilation with C23

### DIFF
--- a/bind/gen.go
+++ b/bind/gen.go
@@ -52,7 +52,9 @@ package main
 %[3]s
 // #define Py_LIMITED_API // need full API for PyRun*
 #include <Python.h>
+#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 202311L)
 typedef uint8_t bool;
+#endif
 // static inline is trick for avoiding need for extra .c file
 // the following are used for build value -- switch on reflect.Kind
 // or the types equivalent
@@ -410,7 +412,7 @@ build:
 	$(GOIMPORTS) -w %[1]s.go
 	# this will otherwise be built during go build and may be out of date
 	- rm %[1]s.c 
-	echo "typedef uint8_t bool;" > %[1]s_go.h
+	printf "#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 202311L)\ntypedef uint8_t bool;\n#endif\n" > %[1]s_go.h
 	# this will fail but is needed to generate the .c file that then allows go build to work
 	- $(PYTHON) build.py >/dev/null 2>&1
 	# generate %[1]s_go.h from %[1]s.go -- unfortunately no way to build .h only

--- a/cmd_build.go
+++ b/cmd_build.go
@@ -125,7 +125,7 @@ func runBuild(mode bind.BuildMode, cfg *BuildCfg) error {
 
 	if mode == bind.ModeExe {
 		of, err := os.Create(buildname + ".h") // overwrite existing
-		fmt.Fprintf(of, "typedef uint8_t bool;\n")
+		fmt.Fprintf(of, "#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 202311L)\ntypedef uint8_t bool;\n#endif\n")
 		of.Close()
 
 		fmt.Printf("%v build.py   # will fail, but needed to generate .c file\n", cfg.VM)


### PR DESCRIPTION
GCC 15 has been released (fairly) recently, and with it come C23 features such as built-in `bool` types, which obviate the need for defining these in each code-base.

In our case, this also causes compilation errors with GCC 15 (unless the `-std=gnu17` flag is passed), e.g.:

```
./test.go:16:17: error: two or more data types in declaration specifiers
   16 | typedef uint8_t bool;
      |                 ^~~~
```

This commit wraps these `typedef` declarations in `__STDC_VERSION__` checks, skipping if the version is C23 or over.