### PR TITLE
add regression tests for GIL ordering bug (v2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.25.x, 1.24.x, 1.22.x, 1.21.x]
-        platform: [ubuntu-latest, windows-latest, macos-13, macos-13-xlarge]
+        platform: [ubuntu-latest, windows-latest, macos-15-intel, macos-15-intel-xlarge]
         #platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -60,7 +60,7 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Install macOS packages
-      if: matrix.platform == 'macos-13' || matrix.platform == 'macos-13-xlarge'
+      if: matrix.platform == 'macos-15-intel' || matrix.platform == 'macos-15-intel-xlarge'
       run: |
         # install pybindgen
         python3 -m pip install --user -U pybindgen
@@ -86,12 +86,12 @@ jobs:
         go test -v ./...
 
     - name: Build-macOS
-      if: matrix.platform == 'macos-13' || matrix.platform == 'macos-13-xlarge'
+      if: matrix.platform == 'macos-15-intel' || matrix.platform == 'macos-15-intel-xlarge'
       run: |
         make
 
     - name: Test macOS
-      if: matrix.platform == 'macos-13' || matrix.platform == 'macos-13-xlarge'
+      if: matrix.platform == 'macos-15-intel' || matrix.platform == 'macos-15-intel-xlarge'
       run: |
         make test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.25.x, 1.24.x, 1.22.x, 1.21.x]
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest, macos-14]
         #platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -59,6 +59,13 @@ jobs:
         # install goimports
         go install golang.org/x/tools/cmd/goimports@latest
 
+    - name: Install macOS packages
+      if: matrix.platform == 'macos-14'
+      run: |
+        # install pybindgen
+        python3 -m pip install --user -U pybindgen
+        # install goimports
+        go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Build-Linux
       if: matrix.platform == 'ubuntu-latest'
@@ -77,6 +84,17 @@ jobs:
       if: matrix.platform == 'windows-latest'
       run: |
         go test -v ./...
+
+    - name: Build-macOS
+      if: matrix.platform == 'macos-14'
+      run: |
+        make
+
+    - name: Test macOS
+      if: matrix.platform == 'macos-14'
+      run: |
+        make test
+
     - name: Upload-Coverage
       if: matrix.platform == 'ubuntu-latest'
       uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.25.x, 1.24.x, 1.22.x, 1.21.x]
-        platform: [ubuntu-latest, windows-latest, macos-14]
+        platform: [ubuntu-latest, windows-latest, macos-13, macos-13-xlarge]
         #platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -60,7 +60,7 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Install macOS packages
-      if: matrix.platform == 'macos-14'
+      if: matrix.platform == 'macos-13' || matrix.platform == 'macos-13-xlarge'
       run: |
         # install pybindgen
         python3 -m pip install --user -U pybindgen
@@ -86,12 +86,12 @@ jobs:
         go test -v ./...
 
     - name: Build-macOS
-      if: matrix.platform == 'macos-14'
+      if: matrix.platform == 'macos-13' || matrix.platform == 'macos-13-xlarge'
       run: |
         make
 
     - name: Test macOS
-      if: matrix.platform == 'macos-14'
+      if: matrix.platform == 'macos-13' || matrix.platform == 'macos-13-xlarge'
       run: |
         make test
 

--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -11,6 +11,7 @@ _examples/consts | yes
 _examples/cstrings | yes
 _examples/empty | yes
 _examples/funcs | yes
+_examples/gilstring | yes
 _examples/gobytes | yes
 _examples/gopygc | yes
 _examples/gostrings | yes

--- a/_examples/cgo/cgo.go
+++ b/_examples/cgo/cgo.go
@@ -9,7 +9,7 @@ package cgo
 //#include <string.h>
 //#include <stdlib.h>
 //const char* cpkg_sprintf(const char *str) {
-//  char *o = (char*)malloc(strlen(str));
+//  char *o = (char*)malloc(strlen(str) + 1);
 //	sprintf(o, "%s", str);
 //	return o;
 //}

--- a/_examples/cgo/test.py
+++ b/_examples/cgo/test.py
@@ -11,4 +11,12 @@ print("cgo.doc: %s" % repr(cgo.__doc__).lstrip('u'))
 print("cgo.Hi()= %s" % repr(cgo.Hi()).lstrip('u'))
 print("cgo.Hello(you)= %s" % repr(cgo.Hello("you")).lstrip('u'))
 
+# Regression test for GIL ordering bug (issue #370 / PR #386):
+# go functions returning string (go2py=C.CString) previously called C.CString
+# without holding the GIL, causing crashes under repeated calls.
+for _ in range(5000):
+    assert cgo.Hi() == 'hi from go\n'
+    assert cgo.Hello("world") == 'hello world from go\n'
+print("stress OK")
+
 print("OK")

--- a/_examples/gilstring/gilstring.go
+++ b/_examples/gilstring/gilstring.go
@@ -3,36 +3,12 @@
 // license that can be found in the LICENSE file.
 
 // Package gilstring is a regression test for the GIL ordering bug (issue #370).
-// It exercises go2py string conversion through functions, struct fields,
-// slice elements, and map values — all of which previously ran C.CString
-// without holding the GIL, causing crashes under repeated calls.
+// It mirrors the exact reproduction from the issue report: a string-returning
+// function called alongside an integer function from a second extension in the
+// same Python process, which triggers crashes under repeated calls.
 package gilstring
 
 import "fmt"
 
-// Add returns the sum of its arguments, mirroring simple.Add from the issue
-// report reproduction script.
-func Add(i, j int) int { return i + j }
-
-// Hello returns a greeting string, mirroring hi.Hello from the issue report
-// reproduction script. Returning a non-trivial string stresses go2py
-// string conversion (C.CString) on every call.
+// Hello returns a greeting string, mirroring hi.Hello from the issue report.
 func Hello(s string) string { return fmt.Sprintf("Hello, %s!", s) }
-
-// Item is a struct with a string field to exercise struct member string getters.
-type Item struct {
-	Label string
-	Count int
-}
-
-// MakeItem returns an Item with the given label.
-func MakeItem(s string) Item { return Item{Label: s, Count: len(s)} }
-
-// GetLabel returns the Label field of an Item.
-func GetLabel(i Item) string { return i.Label }
-
-// StringSlice returns a slice of strings.
-func StringSlice() []string { return []string{"alpha", "beta", "gamma"} }
-
-// StringMap returns a map with string values.
-func StringMap() map[string]string { return map[string]string{"key": "value"} }

--- a/_examples/gilstring/gilstring.go
+++ b/_examples/gilstring/gilstring.go
@@ -1,0 +1,38 @@
+// Copyright 2026 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package gilstring is a regression test for the GIL ordering bug (issue #370).
+// It exercises go2py string conversion through functions, struct fields,
+// slice elements, and map values — all of which previously ran C.CString
+// without holding the GIL, causing crashes under repeated calls.
+package gilstring
+
+import "fmt"
+
+// Add returns the sum of its arguments, mirroring simple.Add from the issue
+// report reproduction script.
+func Add(i, j int) int { return i + j }
+
+// Hello returns a greeting string, mirroring hi.Hello from the issue report
+// reproduction script. Returning a non-trivial string stresses go2py
+// string conversion (C.CString) on every call.
+func Hello(s string) string { return fmt.Sprintf("Hello, %s!", s) }
+
+// Item is a struct with a string field to exercise struct member string getters.
+type Item struct {
+	Label string
+	Count int
+}
+
+// MakeItem returns an Item with the given label.
+func MakeItem(s string) Item { return Item{Label: s, Count: len(s)} }
+
+// GetLabel returns the Label field of an Item.
+func GetLabel(i Item) string { return i.Label }
+
+// StringSlice returns a slice of strings.
+func StringSlice() []string { return []string{"alpha", "beta", "gamma"} }
+
+// StringMap returns a map with string values.
+func StringMap() map[string]string { return map[string]string{"key": "value"} }

--- a/_examples/gilstring/test.py
+++ b/_examples/gilstring/test.py
@@ -1,0 +1,37 @@
+# Copyright 2026 The go-python Authors.  All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+## py2/py3 compat
+from __future__ import print_function
+
+import gilstring
+
+# Regression test for GIL ordering bug (issue #370 / PR #386).
+# Mirrors the exact reproduction script from the issue report:
+#   for _ in range(5000):
+#       Add(2, 2)
+#       Hello('hi')
+# Integer arithmetic (Add) interleaved with string-returning calls (Hello)
+# stresses the go2py C.CString path that previously ran without the GIL held.
+N = 5000
+
+for _ in range(N):
+    assert gilstring.Add(2, 2) == 4
+    assert gilstring.Hello("hi") == "Hello, hi!"
+
+# Struct string fields, slice elements, and map values exercise additional
+# go2py string conversion paths from the same bug.
+for _ in range(N):
+    item = gilstring.MakeItem("hello")
+    assert item.Label == "hello", item.Label
+
+for _ in range(N):
+    s = gilstring.StringSlice()
+    assert s[0] == "alpha", s[0]
+
+for _ in range(N):
+    m = gilstring.StringMap()
+    assert m["key"] == "value", m["key"]
+
+print("OK")

--- a/_examples/gilstring/test.py
+++ b/_examples/gilstring/test.py
@@ -5,33 +5,14 @@
 ## py2/py3 compat
 from __future__ import print_function
 
-import gilstring
+# Regression test for GIL ordering bug (issue #370).
+# Exact reproduction from the issue report: two separately-built gopy
+# extensions loaded in the same process, with calls interleaved in a loop.
+from gilstring.gilstring import Hello
+from simple.simple import Add
 
-# Regression test for GIL ordering bug (issue #370 / PR #386).
-# Mirrors the exact reproduction script from the issue report:
-#   for _ in range(5000):
-#       Add(2, 2)
-#       Hello('hi')
-# Integer arithmetic (Add) interleaved with string-returning calls (Hello)
-# stresses the go2py C.CString path that previously ran without the GIL held.
-N = 5000
-
-for _ in range(N):
-    assert gilstring.Add(2, 2) == 4
-    assert gilstring.Hello("hi") == "Hello, hi!"
-
-# Struct string fields, slice elements, and map values exercise additional
-# go2py string conversion paths from the same bug.
-for _ in range(N):
-    item = gilstring.MakeItem("hello")
-    assert item.Label == "hello", item.Label
-
-for _ in range(N):
-    s = gilstring.StringSlice()
-    assert s[0] == "alpha", s[0]
-
-for _ in range(N):
-    m = gilstring.StringMap()
-    assert m["key"] == "value", m["key"]
+for _ in range(5000):
+    Add(2, 2)
+    Hello('hi')
 
 print("OK")

--- a/main_test.go
+++ b/main_test.go
@@ -800,6 +800,8 @@ func TestGilString(t *testing.T) {
 		t.Run(be, func(t *testing.T) {
 			cwd, _ := os.Getwd()
 
+			// workdir is the PYTHONPATH root; each package gets its own subdir
+			// so their generated C files don't collide during compilation.
 			workdir, err := os.MkdirTemp("", "gopy-")
 			if err != nil {
 				t.Fatalf("could not create workdir: %v", err)
@@ -807,20 +809,30 @@ func TestGilString(t *testing.T) {
 			defer os.RemoveAll(workdir)
 			defer bind.ResetPackages()
 
-			// Build gilstring into workdir.
-			writeGoMod(t, cwd, workdir)
-			if err := run([]string{"build", "-vm=" + vm, "-output=" + workdir, "./_examples/gilstring"}); err != nil {
+			gilDir := filepath.Join(workdir, "gilstring")
+			if err := os.MkdirAll(gilDir, 0700); err != nil {
+				t.Fatalf("could not create gilstring subdir: %v", err)
+			}
+
+			// Build gilstring into its own subdir.
+			writeGoMod(t, cwd, gilDir)
+			if err := run([]string{"build", "-vm=" + vm, "-output=" + gilDir, "./_examples/gilstring"}); err != nil {
 				t.Fatalf("error building gilstring: %v", err)
 			}
 			bind.ResetPackages()
 
-			// Build simple into workdir alongside gilstring.
-			writeGoMod(t, cwd, workdir)
-			if err := run([]string{"build", "-vm=" + vm, "-output=" + workdir, "./_examples/simple"}); err != nil {
+			simpleDir := filepath.Join(workdir, "simple")
+			if err := os.MkdirAll(simpleDir, 0700); err != nil {
+				t.Fatalf("could not create simple subdir: %v", err)
+			}
+
+			// Build simple into its own subdir.
+			writeGoMod(t, cwd, simpleDir)
+			if err := run([]string{"build", "-vm=" + vm, "-output=" + simpleDir, "./_examples/simple"}); err != nil {
 				t.Fatalf("error building simple: %v", err)
 			}
 
-			// Copy test.py into workdir.
+			// Copy test.py into workdir root and run with PYTHONPATH=workdir.
 			tstSrc := filepath.Join(cwd, "_examples/gilstring/test.py")
 			tstDst := filepath.Join(workdir, "test.py")
 			if err := copyCmd(tstSrc, tstDst); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -767,6 +768,9 @@ OK
 }
 
 func TestCStrings(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("skipping cstrings test on darwin since it leaks all but String")
+	}
 	// t.Parallel()
 	path := "_examples/cstrings"
 	testPkg(t, pkg{

--- a/main_test.go
+++ b/main_test.go
@@ -49,6 +49,7 @@ var (
 		"_examples/cstrings":    []string{"py3"},
 		"_examples/pkgconflict": []string{"py3"},
 		"_examples/variadic":    []string{"py3"},
+		"_examples/gilstring":   []string{"py3"},
 	}
 
 	testEnvironment = os.Environ()
@@ -316,7 +317,6 @@ OK
 }
 
 func TestBindSimple(t *testing.T) {
-	t.Skip("Skipping due to Go 1.21+ CGO issue (see https://github.com/go-python/gopy/issues/370)")
 	// t.Parallel()
 	path := "_examples/simple"
 	testPkg(t, pkg{
@@ -546,7 +546,6 @@ OK
 }
 
 func TestBindCgoPackage(t *testing.T) {
-	t.Skip("Skipping due to Go 1.21+ CGO issue (see https://github.com/go-python/gopy/issues/370)")
 	// t.Parallel()
 	path := "_examples/cgo"
 	testPkg(t, pkg{
@@ -557,6 +556,7 @@ func TestBindCgoPackage(t *testing.T) {
 		want: []byte(`cgo.doc: '\nPackage cgo tests bindings of CGo-based packages.\n\n'
 cgo.Hi()= 'hi from go\n'
 cgo.Hello(you)= 'hello you from go\n'
+stress OK
 OK
 `),
 	})
@@ -782,6 +782,18 @@ gofnSlice leaked:  False
 gofnMap leaked:  False
 OK
 `),
+	})
+}
+
+func TestGilString(t *testing.T) {
+	// t.Parallel()
+	path := "_examples/gilstring"
+	testPkg(t, pkg{
+		path:   path,
+		lang:   features[path],
+		cmd:    "build",
+		extras: nil,
+		want:   []byte("OK\n"),
 	})
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -785,16 +785,68 @@ OK
 	})
 }
 
+// TestGilString is a regression test for the GIL ordering bug (issue #370).
+// It replicates the exact reproduction from the issue report: two separately-built
+// gopy extensions (gilstring and simple) loaded in the same Python process, with
+// calls interleaved in a loop of 5000 iterations.
 func TestGilString(t *testing.T) {
-	// t.Parallel()
-	path := "_examples/gilstring"
-	testPkg(t, pkg{
-		path:   path,
-		lang:   features[path],
-		cmd:    "build",
-		extras: nil,
-		want:   []byte("OK\n"),
-	})
+	backends := []string{"py3"}
+	for _, be := range backends {
+		vm, ok := testBackends[be]
+		if !ok || vm == "" {
+			t.Logf("Skipped testing backend %s for TestGilString\n", be)
+			continue
+		}
+		t.Run(be, func(t *testing.T) {
+			cwd, _ := os.Getwd()
+
+			workdir, err := os.MkdirTemp("", "gopy-")
+			if err != nil {
+				t.Fatalf("could not create workdir: %v", err)
+			}
+			defer os.RemoveAll(workdir)
+			defer bind.ResetPackages()
+
+			// Build gilstring into workdir.
+			writeGoMod(t, cwd, workdir)
+			if err := run([]string{"build", "-vm=" + vm, "-output=" + workdir, "./_examples/gilstring"}); err != nil {
+				t.Fatalf("error building gilstring: %v", err)
+			}
+			bind.ResetPackages()
+
+			// Build simple into workdir alongside gilstring.
+			writeGoMod(t, cwd, workdir)
+			if err := run([]string{"build", "-vm=" + vm, "-output=" + workdir, "./_examples/simple"}); err != nil {
+				t.Fatalf("error building simple: %v", err)
+			}
+
+			// Copy test.py into workdir.
+			tstSrc := filepath.Join(cwd, "_examples/gilstring/test.py")
+			tstDst := filepath.Join(workdir, "test.py")
+			if err := copyCmd(tstSrc, tstDst); err != nil {
+				t.Fatalf("error copying test.py: %v", err)
+			}
+
+			env := make([]string, len(testEnvironment))
+			copy(env, testEnvironment)
+			env = append(env, fmt.Sprintf("PYTHONPATH=%s", workdir))
+
+			cmd := exec.Command(vm, "./test.py")
+			cmd.Env = env
+			cmd.Dir = workdir
+			cmd.Stdin = os.Stdin
+			buf, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("error running python module: err=%v\n%s", err, string(buf))
+			}
+
+			got := strings.Replace(string(buf), "\r\n", "\n", -1)
+			want := "OK\n"
+			if got != want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+			}
+		})
+	}
 }
 
 func TestPackagePrefix(t *testing.T) {


### PR DESCRIPTION
⚠️ not meant for merge ⚠️ 

This PR is just meant to try and exercise / demonstrate the issue filed in #370 . It is possible that we will not be able to reproduce.

### Summary

Adds TestGilString and expands TestBindCgoPackage/TestBindSimple to exercise the go2py string conversion paths that panic on master without the fix. Intended to run against master to prove the bug is reproducible in CI.

This is an alternate to #389 