### PR TITLE
Fix crash when converting 0-length Go []byte to Python bytes

### DIFF
--- a/_examples/gobytes/test.py
+++ b/_examples/gobytes/test.py
@@ -22,4 +22,12 @@ empty_bytes = bytes(empty)
 assert empty_bytes == b"", "expected b'', got %r" % (empty_bytes,)
 print("Go empty bytes to Python: ", empty_bytes)
 
+# Regression test for issue #359 (reverse direction): converting a 0-length
+# Python bytes to a Go []byte, then back, must not crash either.
+empty_from_bytes = go.Slice_byte.from_bytes(b"")
+print("Python empty bytes to Go: ", empty_from_bytes)
+roundtrip_bytes = bytes(empty_from_bytes)
+assert roundtrip_bytes == b"", "expected b'', got %r" % (roundtrip_bytes,)
+print("Go empty bytes round-trip: ", roundtrip_bytes)
+
 print("OK")

--- a/_examples/gobytes/test.py
+++ b/_examples/gobytes/test.py
@@ -15,4 +15,11 @@ print ("gobytes.HashBytes from Go bytes:", gobytes.HashBytes(b))
 print("Python bytes to Go: ", go.Slice_byte.from_bytes(a))
 print("Go bytes to Python: ", bytes(go.Slice_byte([3, 4, 5])))
 
+# Regression test for issue #359: 0-length slice must not crash
+empty = gobytes.CreateBytes(0)
+print("Go empty slice: ", empty)
+empty_bytes = bytes(empty)
+assert empty_bytes == b"", "expected b'', got %r" % (empty_bytes,)
+print("Go empty bytes to Python: ", empty_bytes)
+
 print("OK")

--- a/bind/gen_slice.go
+++ b/bind/gen_slice.go
@@ -411,6 +411,11 @@ otherwise parameter is a python list that we copy from
 			g.gofile.Printf("func Slice_byte_to_bytes(handle CGoHandle) *C.PyObject {\n")
 			g.gofile.Indent()
 			g.gofile.Printf("s := deptrFromHandle_Slice_byte(handle)\n")
+			g.gofile.Printf("if len(s) == 0 {\n")
+			g.gofile.Indent()
+			g.gofile.Printf("return C.PyBytes_FromStringAndSize(nil, 0)\n")
+			g.gofile.Outdent()
+			g.gofile.Printf("}\n")
 			g.gofile.Printf("ptr := unsafe.Pointer(&s[0])\n")
 			g.gofile.Printf("size := len(s)\n")
 			if WindowsOS {

--- a/main_test.go
+++ b/main_test.go
@@ -284,6 +284,8 @@ Python bytes to Go:  go.Slice_byte len: 4 handle: 3 [0, 1, 2, 3]
 Go bytes to Python:  b'\x03\x04\x05'
 Go empty slice:  go.Slice_byte len: 0 handle: 5 []
 Go empty bytes to Python:  b''
+Python empty bytes to Go:  go.Slice_byte len: 0 handle: 6 []
+Go empty bytes round-trip:  b''
 OK
 `),
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -282,6 +282,8 @@ Go slice:  go.Slice_byte len: 10 handle: 1 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 gobytes.HashBytes from Go bytes: gobytes.Array_4_byte len: 4 handle: 2 [12, 13, 81, 81]
 Python bytes to Go:  go.Slice_byte len: 4 handle: 3 [0, 1, 2, 3]
 Go bytes to Python:  b'\x03\x04\x05'
+Go empty slice:  go.Slice_byte len: 0 handle: 5 []
+Go empty bytes to Python:  b''
 OK
 `),
 	})


### PR DESCRIPTION
Fixes #359 

`Slice_byte_to_bytes` indexed `s[0]` unconditionally, causing a runtime panic on empty slices. Guard with an early return via `PyBytes_FromStringAndSize(nil, 0)` which the CPython API handles correctly.