### PR TITLE
fix: add gobytes test - round-tripped & re-encoded

### DIFF
--- a/_examples/gobytes/test.py
+++ b/_examples/gobytes/test.py
@@ -22,4 +22,12 @@ empty_bytes = bytes(empty)
 assert empty_bytes == b"", "expected b'', got %r" % (empty_bytes,)
 print("Go empty bytes to Python: ", empty_bytes)
 
+# Regression test for issue #359 (reverse direction): converting a 0-length
+# Python bytes to a Go []byte, then back, must not crash either.
+empty_from_bytes = go.Slice_byte.from_bytes(b"")
+print("Python empty bytes to Go: ", empty_from_bytes)
+roundtrip_bytes = bytes(empty_from_bytes)
+assert roundtrip_bytes == b"", "expected b'', got %r" % (roundtrip_bytes,)
+print("Go empty bytes round-trip: ", roundtrip_bytes)
+
 print("OK")

--- a/main_test.go
+++ b/main_test.go
@@ -284,6 +284,8 @@ Python bytes to Go:  go.Slice_byte len: 4 handle: 3 [0, 1, 2, 3]
 Go bytes to Python:  b'\x03\x04\x05'
 Go empty slice:  go.Slice_byte len: 0 handle: 5 []
 Go empty bytes to Python:  b''
+Python empty bytes to Go:  go.Slice_byte len: 0 handle: 6 []
+Go empty bytes round-trip:  b''
 OK
 `),
 	})


### PR DESCRIPTION
Adds one new assertion — `go.Slice_byte.from_bytes(b"")` (round-tripped and re-encoded), which is currently-untested surface area

Note: this PR is stacked atop https://github.com/go-python/gopy/pull/394 .