### PR TITLE
bind: make _gopy_clear_go_tls opt-in, off by default

### DIFF
--- a/bind/gen.go
+++ b/bind/gen.go
@@ -329,12 +329,13 @@ cwd = os.getcwd()
 currentdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 os.chdir(currentdir)
 # When multiple gopy extensions coexist in one Python process each carries its own
-# independent Go runtime. The Go extension is loaded without RTLD_GLOBAL below, and
-# _gopy_clear_go_tls() is called before each CGo entry to force needm() to run, which
-# establishes the correct per-extension M/P/mcache context (issue #370).
-# Also load the extension without RTLD_GLOBAL so that Go runtime symbols stay
-# local to each .so — belt-and-suspenders on platforms where RTLD_GLOBAL is the
-# Python default (e.g. some Linux builds).
+# independent Go runtime. Loading each extension without RTLD_GLOBAL below keeps its
+# Go runtime symbols (including the per-runtime goroutine-pointer TLS slot) local to
+# its own .so, which is what prevents the runtimes from colliding (issue #370).
+# A _gopy_clear_go_tls() call before each CGo entry is available as an extra safety
+# net but is opt-in (gopy build -clear-go-tls), off by default: on glibc + CPython
+# 3.12+ its hardcoded TLS store clobbers the interpreter thread state and crashes on
+# the first call in the common single-extension case (issue #395).
 if hasattr(sys, 'getdlopenflags'):
 	try:
 		import ctypes as _gopy_ctypes
@@ -517,6 +518,17 @@ var NoWarn = false
 
 // NoMake turns off generation of Makefiles
 var NoMake = false
+
+// ClearGoTLS controls whether generated wrappers emit a _gopy_clear_go_tls()
+// call before every CGo entry point (issue #370). It is opt-in and off by
+// default. The clear performs a hardcoded TLS store (movq $0, %gs:0x30 on
+// darwin/amd64, movq $0, %fs:-8 on linux/amd64); with a single gopy extension
+// in the process it is unnecessary, and on glibc + CPython 3.12+ that offset
+// overlaps the TLS slot CPython uses for the current thread state, so the store
+// nulls it and the interpreter segfaults on the first call (issue #395).
+// Loading each extension without RTLD_GLOBAL, done unconditionally, already
+// keeps each runtime's goroutine-pointer TLS local to its own .so.
+var ClearGoTLS = false
 
 // GenPyBind generates a .go file, build.py file to enable pybindgen to create python bindings,
 // and wrapper .py file(s) that are loaded as the interface to the package with shadow

--- a/bind/gen_func.go
+++ b/bind/gen_func.go
@@ -339,8 +339,13 @@ if __err != nil {
 	// Clear the Go TLS goroutine slot before the CGo entry point so that
 	// Go's needm() runs and establishes the correct per-extension context.
 	// Without this, two extensions sharing the same process can corrupt
-	// each other's heap via TLS collision (issue #370).
-	g.pywrap.Printf("_%s._gopy_clear_go_tls()\n", pkgname)
+	// each other's heap via TLS collision (issue #370). Opt-in and off by
+	// default: the hardcoded TLS store crashes CPython 3.12+ in the common
+	// single-extension case (issue #395), and RTLD_GLOBAL-local loading
+	// already isolates each runtime's goroutine-pointer TLS.
+	if ClearGoTLS {
+		g.pywrap.Printf("_%s._gopy_clear_go_tls()\n", pkgname)
+	}
 
 	// pywrap output
 	mnm := fsym.ID()

--- a/cmd_build.go
+++ b/cmd_build.go
@@ -45,6 +45,7 @@ ex:
 	cmd.Flag.Bool("symbols", true, "include symbols in output")
 	cmd.Flag.Bool("no-warn", false, "suppress warning messages, which may be expected")
 	cmd.Flag.Bool("no-make", false, "do not generate a Makefile, e.g., when called from Makefile")
+	cmd.Flag.Bool("clear-go-tls", false, "emit a _gopy_clear_go_tls() call before every CGo entry (issue #370); off by default, needed only when several gopy extensions share one process and known to crash CPython 3.12+ (issue #395)")
 	cmd.Flag.Bool("dynamic-link", false, "whether to link output shared library dynamically to Python")
 	cmd.Flag.String("build-tags", "", "build tags to be passed to `go build`")
 	return cmd
@@ -72,6 +73,7 @@ func gopyRunCmdBuild(cmdr *commander.Command, args []string) error {
 
 	bind.NoWarn = cfg.NoWarn
 	bind.NoMake = cfg.NoMake
+	bind.ClearGoTLS = cmdr.Flag.Lookup("clear-go-tls").Value.Get().(bool)
 
 	for _, path := range args {
 		bpkg, err := loadPackage(path, true, cfg.BuildTags) // build first

--- a/cmd_exe.go
+++ b/cmd_exe.go
@@ -58,6 +58,7 @@ ex:
 	cmd.Flag.String("url", "https://github.com/go-python/gopy", "home page for project")
 	cmd.Flag.Bool("no-warn", false, "suppress warning messages, which may be expected")
 	cmd.Flag.Bool("no-make", false, "do not generate a Makefile, e.g., when called from Makefile")
+	cmd.Flag.Bool("clear-go-tls", false, "emit a _gopy_clear_go_tls() call before every CGo entry (issue #370); off by default, needed only when several gopy extensions share one process and known to crash CPython 3.12+ (issue #395)")
 	cmd.Flag.Bool("dynamic-link", false, "whether to link output shared library dynamically to Python")
 	cmd.Flag.String("build-tags", "", "build tags to be passed to `go build`")
 
@@ -97,6 +98,7 @@ func gopyRunCmdExe(cmdr *commander.Command, args []string) error {
 
 	bind.NoWarn = cfg.NoWarn
 	bind.NoMake = cfg.NoMake
+	bind.ClearGoTLS = cmdr.Flag.Lookup("clear-go-tls").Value.Get().(bool)
 
 	if cfg.Name == "" {
 		path := args[0]

--- a/cmd_gen.go
+++ b/cmd_gen.go
@@ -37,6 +37,7 @@ ex:
 	cmd.Flag.Bool("rename", false, "rename Go symbols to python PEP snake_case")
 	cmd.Flag.Bool("no-warn", false, "suppress warning messages, which may be expected")
 	cmd.Flag.Bool("no-make", false, "do not generate a Makefile, e.g., when called from Makefile")
+	cmd.Flag.Bool("clear-go-tls", false, "emit a _gopy_clear_go_tls() call before every CGo entry (issue #370); off by default, needed only when several gopy extensions share one process and known to crash CPython 3.12+ (issue #395)")
 	cmd.Flag.Bool("dynamic-link", false, "whether to link output shared library dynamically to Python")
 	cmd.Flag.String("build-tags", "", "build tags to be passed to `go build`")
 	return cmd
@@ -69,6 +70,7 @@ func gopyRunCmdGen(cmdr *commander.Command, args []string) error {
 
 	bind.NoWarn = cfg.NoWarn
 	bind.NoMake = cfg.NoMake
+	bind.ClearGoTLS = cmdr.Flag.Lookup("clear-go-tls").Value.Get().(bool)
 
 	for _, path := range args {
 		bpkg, err := loadPackage(path, true, cfg.BuildTags) // build first

--- a/cmd_pkg.go
+++ b/cmd_pkg.go
@@ -55,6 +55,7 @@ ex:
 	cmd.Flag.String("url", "https://github.com/go-python/gopy", "home page for project")
 	cmd.Flag.Bool("no-warn", false, "suppress warning messages, which may be expected")
 	cmd.Flag.Bool("no-make", false, "do not generate a Makefile, e.g., when called from Makefile")
+	cmd.Flag.Bool("clear-go-tls", false, "emit a _gopy_clear_go_tls() call before every CGo entry (issue #370); off by default, needed only when several gopy extensions share one process and known to crash CPython 3.12+ (issue #395)")
 	cmd.Flag.Bool("dynamic-link", false, "whether to link output shared library dynamically to Python")
 	cmd.Flag.String("build-tags", "", "build tags to be passed to `go build`")
 
@@ -93,6 +94,7 @@ func gopyRunCmdPkg(cmdr *commander.Command, args []string) error {
 
 	bind.NoWarn = cfg.NoWarn
 	bind.NoMake = cfg.NoMake
+	bind.ClearGoTLS = cmdr.Flag.Lookup("clear-go-tls").Value.Get().(bool)
 
 	if cfg.Name == "" {
 		path := args[0]


### PR DESCRIPTION
## Summary

The `_gopy_clear_go_tls()` call added for issue #370 runs unconditionally before every CGo entry and performs a hardcoded TLS store (`movq $0, %fs:-8` on linux/amd64, `movq $0, %gs:0x30` on darwin/amd64). On glibc + CPython 3.12+ that offset overlaps the TLS slot CPython uses for the current thread state (`_Py_tss_tstate`), so the store nulls it and the interpreter segfaults on the first call: in the common **single-extension** case, which structurally cannot have the cross-runtime collision the clear was meant to guard against.

This PR makes the clear **opt-in** via a new `-clear-go-tls` build flag (default `false`): the default build is safe, and the previous behavior stays one flag away.

Fixes #395.

## The two problems with the unconditional clear

1. **It runs for a single extension too.** That is the common case and the one that cannot have a cross-runtime TLS collision, so there the clear is pure downside.
2. **The address is wrong for `c-shared` under glibc.** In a normal Go binary the runtime lays out its TLS so the g pointer sits at `%fs:-8`. In a `c-shared` library loaded by glibc the loader owns the static TLS block and the g pointer is reached through a linker-assigned TLS variable (`runtime.tls_g`), not a fixed `-8`. So `movq $0, %fs:-8` does not clear Go's g at all: it zeroes whatever thread-local happens to sit there, which on CPython 3.12+ is `_Py_tss_tstate`.

PR #393 already shipped the mechanism that actually isolates the runtimes: each extension is loaded without `RTLD_GLOBAL`, and gopy links each `.so` with a version script exporting only `PyInit_*`. Both keep every Go runtime symbol (including the g-pointer TLS) local to its own `.so`, so there is nothing shared to collide over. The raw-TLS clear is therefore redundant, and with the wrong offset actively harmful.

## What this PR changes

- Adds a `bind.ClearGoTLS` option and a `-clear-go-tls` build flag (default `false`), mirroring the existing `-no-make` flag across `cmd_build.go`, `cmd_gen.go`, `cmd_pkg.go`, `cmd_exe.go`.
- Gates the single `_gopy_clear_go_tls()` emission site in `bind/gen_func.go` on that flag.
- Leaves the C helper and its pybindgen registration in place, so `-clear-go-tls` restores today's behavior exactly.
- Leaves the `RTLD_GLOBAL` handling untouched and unconditional.

6 files, +33/-8. `gofmt`, `go vet ./...`, and `go test ./bind/` are clean.

## Verification

**Downstream (the crashing project).** Gentoo, glibc, CPython 3.14.6, go 1.26.4,
gcc 16. Rebuilding slidge-whatsapp's extension:

- Default (clear off): the generated wrapper contains zero `_gopy_clear_go_tls()` sites and the first call succeeds (exit 0).
- `gopy build -clear-go-tls`: the call reappears (one per CGo entry) and the crash returns (SIGSEGV, exit 139).

So the flag is a faithful toggle, and off-by-default removes the crash with no post-build patching.

**Multi-extension case, clear off.** Two independent gopy extensions (two Go runtimes) loaded in one interpreter, 200000 interleaved cross-calls on the same OS thread with periodic `gc.collect()` (the condition #370 describes): 0 wrong results, no crash, no corruption. And each `.so` exports exactly one global dynamic symbol (`PyInit_*`) and zero `runtime.*` symbols, so the g pointer is per-runtime-private regardless of `RTLD_GLOBAL`.

I do not have the original #370 reproducer, so I cannot claim to have re-run that exact case; the opt-in keeps the old behavior available for anyone who needs it.

## Follow-up (optional)

Happy to add regression tests, here or in a follow-up:

1. A codegen assertion (layout-independent): default flags produce a wrapper without `_gopy_clear_go_tls()`, `-clear-go-tls` produces one with it.
2. A two-extension `_examples` coexistence example, cross-called under `gc.collect()`, asserting a clean run with the clear off.
