### PR TITLE
Add regression test for map[string]interface{} int

### DIFF
--- a/_examples/maps/maps.go
+++ b/_examples/maps/maps.go
@@ -43,3 +43,12 @@ func Values(t map[int]float64) []float64 {
 	sort.Float64s(values)
 	return values
 }
+
+// StringInterfaceMap reproduces issue #360: a map[string]interface{} whose
+// values are non-string types (e.g. int) was rendered using Go's fmt "%s"
+// verb, producing "%!s(int=1)" instead of the actual value "1".
+func StringInterfaceMap() map[string]interface{} {
+	return map[string]interface{}{
+		"id": 1,
+	}
+}

--- a/_examples/maps/test.py
+++ b/_examples/maps/test.py
@@ -52,4 +52,9 @@ print('maps.Values from Python dictionary:', maps.Values(maps.Map_int_float64(b)
 del a[1]
 print('deleted 1 from a:', a)
 
+# regression test for issue #360: int values inside a map[string]interface{}
+# must come back as the actual int, not Go's "%!s(int=1)" error string.
+c = maps.StringInterfaceMap()
+print('maps.StringInterfaceMap()["id"]:', c['id'])
+
 print("OK")

--- a/main_test.go
+++ b/main_test.go
@@ -643,6 +643,7 @@ maps.Values from Go map: go.Slice_float64 len: 2 handle: 4 [3.0, 5.0]
 maps.Keys from Python dictionary: go.Slice_int len: 2 handle: 6 [1, 2]
 maps.Values from Python dictionary: go.Slice_float64 len: 2 handle: 8 [3.0, 5.0]
 deleted 1 from a: maps.Map_int_float64 len: 1 handle: 1 {2=5.0, }
+maps.StringInterfaceMap()["id"]: 1
 OK
 `),
 	})


### PR DESCRIPTION
Reproduces issue #360: int values render as Go's "%!s(int=1)" error string.

I'm optimistic that once some of the in-progress work lands (e.g. PR 401), we can merge the `master` branch into this branch to see tests flip from failing to passing.

cc/ @richecr